### PR TITLE
Migrate motoko_agent off the AILANG fork onto upstream v0.15.0 [DRAFT plan-only]

### DIFF
--- a/.agent/plans/AILANG_v0.15.0_Migration.md
+++ b/.agent/plans/AILANG_v0.15.0_Migration.md
@@ -1,0 +1,54 @@
+# AILANG v0.15.0 Migration — pointer
+
+**Status**: Draft PR, awaiting arni's input on provider configuration before code lands
+**Branch**: `ailang-v0.15.0-migration` (this branch)
+**Upstream design doc** (canonical, lives in AILANG repo):
+[design_docs/planned/motoko-agent-v0.15.0-migration.md](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/motoko-agent-v0.15.0-migration.md)
+
+## Why this is in AILANG's repo, not motoko_agent's
+
+The migration plan is co-authored with the AILANG release that makes it possible (v0.15.0). Keeping the canonical doc in `sunholo-data/ailang` means:
+
+- It evolves alongside the upstream features it consumes (M-AI-PROVIDER-CONFIG, M-AI-STREAMING-HELPER)
+- Cross-references to upstream design docs (e.g. `m-ai-provider-config.md`) stay relative-path-stable
+- Linked from [motoko-integration-sequence.md](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/motoko-integration-sequence.md) Phase 3
+
+This file is just a marker — read the upstream doc for the full plan.
+
+## Headline
+
+motoko_agent currently clones a **fork of AILANG** at install time (`scripts/install-prerequisites.sh:363`: `git clone --branch motoko https://github.com/sunholo-data/ailang`). The fork existed to add OpenRouter routing, custom OpenAI base-URL routing, and token streaming — all three are now obsolete in upstream AILANG v0.15.0:
+
+- **OpenRouter routing** → built-in `openrouter` provider in upstream
+- **Custom OpenAI base-URL** → `[[ai_provider]]` block in `ailang.toml` (M-AI-PROVIDER-CONFIG)
+- **Token streaming** → `std/ai/streaming.openaiCompatStream` + event loop (M-AI-STREAMING-HELPER)
+
+This branch implements the migration. **No code changes in this draft commit** — only this plan pointer. Code lands after arni's team answers the questions in the upstream doc's [Questions for arni](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/motoko-agent-v0.15.0-migration.md#questions-for-arni) section.
+
+## Files that will change (8 total, see upstream doc for detail)
+
+| File | Type |
+|------|------|
+| `scripts/install-prerequisites.sh:363` | 1-line clone target swap |
+| `ailang.toml` | Add `ailang = ">=0.15.0"` + `[[ai_provider]]` blocks |
+| `src/core/rpc.ail` | API call-site rewrite (`callStreamResult` → event loop) |
+| `src/core/ext/compose/compose.ail` | Same |
+| `src/core/ext/compose/claimcheck.ail` | Same |
+| `src/core/ext/compose/author_loop.ail` | Same |
+| `src/tui/src/env-server.ts:642` | Update embedded AILANG codegen string |
+| `ailang.toml` (continued) | Provider config blocks per arni's input |
+
+Estimated work: **~4–5 hours** post-arni-ack, four milestones.
+
+## Is the new code "better" or just different?
+
+Honest answer in the upstream doc's [Is the new code better](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/motoko-agent-v0.15.0-migration.md#is-the-new-code-better--or-just-different) section. tl;dr: better in fundamentals (AI cap gating, budget tracking, trace span uniformity, declarative providers), more boilerplate at call sites until v1.1 ships a `callStream` accumulator helper.
+
+## Smoke-test plan (Tier 1 + Tier 2)
+
+Detailed in the upstream doc's [Smoke test plan](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/motoko-agent-v0.15.0-migration.md#smoke-test-plan-before-sending-pr) section. Every commit: `make test` + `ailang check` + TS compile. Pre-PR: real-provider end-to-end run with arni's API key.
+
+---
+
+**Last updated**: 2026-05-05
+**Next action**: arni's team reviews the upstream design doc and answers the 7 questions; this branch then receives the migration commits.


### PR DESCRIPTION
## Status: DRAFT — plan only, no code yet

This PR opens as a draft to get the migration plan in front of the team before any code changes land. The single commit on this branch adds a marker file pointing at the canonical design doc in the AILANG repo:

📄 **Canonical design doc**: https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/motoko-agent-v0.15.0-migration.md

## tl;dr

**[AILANG v0.15.0](https://github.com/sunholo-data/ailang/releases/tag/v0.15.0) (released yesterday) obsoletes the entire reason this project depends on a fork of AILANG.** The three forks-only features all have proper upstream replacements now:

| Fork piece | v0.15.0 replacement |
|------------|---------------------|
| OpenRouter prefix routing | Built-in `openrouter` provider, wired into `ailang run` |
| Custom OpenAI base-URL routing | `[[ai_provider]]` block in `ailang.toml` |
| Token streaming (`std/ai_motoko.callStreamResult`) | `std/ai/streaming.openaiCompatStream` + event loop |

After this migration, `arniwesth/ailang@motoko` can be archived. `motoko_agent` runs on upstream `sunholo-data/ailang@v0.15.0`.

## Scope (from the design doc)

8 files need changes across 4 milestones; estimated **~4-5 hours of work** post-ack:

- 1-line install-script swap (clone upstream tag instead of fork branch)
- `ailang.toml` gains `ailang = ">=0.15.0"` + `[[ai_provider]]` blocks per arni's setup
- 4 `.ail` files using `callStreamResult` get rewritten to the event-loop pattern (~80-120 LOC delta)
- 1 TypeScript file (`src/tui/src/env-server.ts:642`) that emits AILANG code gets its template updated

## Is the new code _better_, or just different?

Honest answer in the [design doc](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/motoko-agent-v0.15.0-migration.md#is-the-new-code-better--or-just-different):

✅ **Better**: AI cap gating (`--caps AI`), per-provider budget tracking, trace span uniformity with non-streaming AI calls, declarative provider config (no Go fork), type-level `!{AI[mode=...]}` markers.

⚠️ **More boilerplate at call sites**: the new API is callback-based (event loop) where the fork was a synchronous accumulator. We propose a small `runStreamCall` helper module in motoko_agent that brings the accumulator back; v1.1 of AILANG will likely ship this in `std/ai/streaming` directly.

## What we need from your team before code lands

Listed in full at the design doc's [Questions for arni section](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/motoko-agent-v0.15.0-migration.md#questions-for-arni). The big ones:

1. **Which AI providers does motoko_agent currently hit?** (OpenAI / OpenRouter / self-hosted / multiple?)
2. **For each: endpoint URL, request_shape, auth method, env var holding the secret?**
3. **Reference test prompt + expected output** so we can verify the migration didn't break behavior?
4. **Do you have bandwidth to help, or should we deliver a complete diff for review?**

## Why open as a draft now

Three reasons:

1. **Plan first, code second** — the API-shape adaptation (`callStreamResult` → event loop) is non-trivial; better to align on approach before any rewrite happens
2. **Provider configs need real values** — the `[[ai_provider]]` blocks in `ailang.toml` need actual endpoints, not placeholders, and only your team knows what's in production
3. **Optional collaboration window** — if your team has bandwidth, this could be a joint migration rather than a "here's a 600-line PR, please review"

## Companion AILANG-side work

The upstream v0.15.0 release that makes this possible was a multi-week effort — design docs, sprint plan, sprint executor, evaluator at 93/100. Captured in the [motoko-integration-sequence.md](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/motoko-integration-sequence.md) master plan. This PR is its Phase 3.

---

Read the [full design doc](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/motoko-agent-v0.15.0-migration.md) when you have a moment — it's structured for a 5-min skim or a 20-min deep read. Would love to hear thoughts before we touch any code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)