### PR TITLE
fix: compaction sub-LLM should be deepseek-v4-flash, not openrouter/auto

### DIFF
--- a/.motoko/config/ailang/compaction_ai.json
+++ b/.motoko/config/ailang/compaction_ai.json
@@ -1,5 +1,5 @@
 {
-  "model": "openrouter/auto",
+  "model": "openrouter/deepseek/deepseek-v4-flash",
   "threshold_pct": 75,
   "keep_recent": 10
 }

--- a/.motoko/config/decision/compaction_ai.json
+++ b/.motoko/config/decision/compaction_ai.json
@@ -1,5 +1,5 @@
 {
-  "model": "openrouter/auto",
+  "model": "openrouter/deepseek/deepseek-v4-flash",
   "threshold_pct": 75,
   "keep_recent": 10
 }

--- a/.motoko/config/default/compaction_ai.json
+++ b/.motoko/config/default/compaction_ai.json
@@ -1,5 +1,5 @@
 {
-  "model": "openrouter/auto",
+  "model": "openrouter/deepseek/deepseek-v4-flash",
   "threshold_pct": 75,
   "keep_recent": 10
 }

--- a/.motoko/config/dogfood/compaction_ai.json
+++ b/.motoko/config/dogfood/compaction_ai.json
@@ -1,5 +1,5 @@
 {
-  "model": "openrouter/auto",
+  "model": "openrouter/deepseek/deepseek-v4-flash",
   "threshold_pct": 75,
   "keep_recent": 10
 }

--- a/.motoko/config/local/compaction_ai.json
+++ b/.motoko/config/local/compaction_ai.json
@@ -1,5 +1,5 @@
 {
-  "model": "openrouter/auto",
+  "model": "openrouter/deepseek/deepseek-v4-flash",
   "threshold_pct": 75,
   "keep_recent": 10
 }

--- a/.motoko/config/mark/compaction_ai.json
+++ b/.motoko/config/mark/compaction_ai.json
@@ -1,5 +1,5 @@
 {
-  "model": "openrouter/auto",
+  "model": "openrouter/deepseek/deepseek-v4-flash",
   "threshold_pct": 75,
   "keep_recent": 10
 }

--- a/.motoko/config/microrag/compaction_ai.json
+++ b/.motoko/config/microrag/compaction_ai.json
@@ -1,5 +1,5 @@
 {
-  "model": "openrouter/auto",
+  "model": "openrouter/deepseek/deepseek-v4-flash",
   "threshold_pct": 75,
   "keep_recent": 10
 }

--- a/.motoko/config/omnigraph/compaction_ai.json
+++ b/.motoko/config/omnigraph/compaction_ai.json
@@ -1,5 +1,5 @@
 {
-  "model": "openrouter/auto",
+  "model": "openrouter/deepseek/deepseek-v4-flash",
   "threshold_pct": 75,
   "keep_recent": 10
 }

--- a/.motoko/config/openrouter/compaction_ai.json
+++ b/.motoko/config/openrouter/compaction_ai.json
@@ -1,5 +1,5 @@
 {
-  "model": "openrouter/auto",
+  "model": "openrouter/deepseek/deepseek-v4-flash",
   "threshold_pct": 75,
   "keep_recent": 10
 }


### PR DESCRIPTION
## Summary

All 9 profiles defaulted the compaction sub-LLM (`.motoko/config/<profile>/compaction_ai.json`'s `.model`) to `openrouter/auto`. Auto routes to frontier-tier models — every compaction call was costing ~10× a solver step. Long sessions burned the cost budget on compaction alone.

Switching to `openrouter/deepseek/deepseek-v4-flash`:

| Model | Cost/1M input | Per compaction (~30K tokens) |
|---|---|---|
| `openrouter/auto` (→ frontier) | ~$3.00 | ~$0.09 |
| `deepseek/deepseek-v4-flash` (this PR) | $0.112 | ~$0.002 |

Same 1M context, same vendor as the main agent (deepseek-v4-pro in most profiles), so no routing surprises.

## Background

Followed up from #16 (which is merged). The compaction misbehavior was reported in motoko inbox `msg_20260517_203439_b0f18350` and traced through to root cause in `msg_20260517_211340_1ada9412`. This PR is the minimal config-only fix; the broader package-side improvements (compaction-loop guard, startup warning when model is `openrouter/auto`, fixing the `context_limit_for` heuristic which still says deepseek=64K but v4 is 1M) need a `motoko_ext_compaction_ai` version bump and will land separately.

## Test plan

- [x] `make check_core` 23/23 still passing.
- [ ] Reviewer eyes on the 9-line diff.
- [ ] Optional: a real motoko session against the `mark`/`dogfood` profile shows `run_summary.total_cost_millicents` dropping vs pre-merge baseline (especially on long sessions with ≥3 compactions).

## Files changed

9 × `.motoko/config/<profile>/compaction_ai.json` — `model` field only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)