### PR TITLE
fix(ci): sync script should only `ailang lock` when manifest was copied

### DIFF
--- a/scripts/sync-extension-packages.sh
+++ b/scripts/sync-extension-packages.sh
@@ -50,7 +50,18 @@ sync_extension() {
   fi
 
   # Generate lock file for the extension package so its dependencies resolve.
-  (cd "$pkg_dir" && ailang lock)
+  # Skip when there's no ailang.toml in the synced dir — this happens when the
+  # extension lives as a local-only override under src/core/ext/<name>/ with
+  # no package manifest (e.g. a quick fork-and-patch of a registry extension
+  # while iterating). In that case the consumer's own ailang.toml (path-dep
+  # or registry-version) covers dependency resolution; nothing to lock here.
+  # Pre-fix this hard-failed CI on PR #22 because src/core/ext/context_mode/
+  # only shipped register.ail with no manifest.
+  if [[ -f "$pkg_dir/ailang.toml" ]]; then
+    (cd "$pkg_dir" && ailang lock)
+  else
+    echo "  (no ailang.toml in $pkg_dir — local-only override, skipping lock)" >&2
+  fi
 
   echo "synced: $ext_name -> .packages/motoko_$ext_name"
 }


### PR DESCRIPTION
## Summary

Unblocks #22 (fix_context_mode_extension) CI by fixing a bug in `scripts/sync-extension-packages.sh`.

## What was broken

The script unconditionally ran `ailang lock` in every synced `.packages/motoko_<ext>/` directory (line 53). When an extension lives as a local-only override under `src/core/ext/<name>/` with no `ailang.toml` (the pattern in #22 — quick fork-and-patch of the registry `context_mode` extension while iterating), the script:

1. ✅ rsync'd `register.ail` into the synced dir (correctly)
2. ❌ skipped the `ailang.toml` copy (correctly — none to copy, guard at line 43)
3. 💥 still ran `ailang lock` (incorrectly — no manifest to lock against)

Result from CI on #22:

```
synced: motoko_core -> .packages/motoko_core
skip: source extension directory missing: src/core/ext/compose
skip: source extension directory missing: src/core/ext/omnigraph
skip: source extension directory missing: src/core/ext/test_dummy
Error: no ailang.toml found in /.../.packages/motoko_context_mode: ...
Run 'ailang init package' first
Process completed with exit code 1.
```

## Fix

3-LOC guard around the lock call on the same condition as the toml copy. Comment explains why and references the surfacing PR. When no manifest was copied, the consumer's own `ailang.toml` (path-dep or registry-version) covers dependency resolution — nothing to lock locally.

## After this merges

@arniwesth — rebase or merge `main` into your `fix_context_mode_extension` branch and CI should go green.

Longer term we're tracking this whole author-loop friction in **M-EXT-AUTHOR-DX** (planned for AILANG v0.20.1) — design doc at [sunholo-data/ailang m-ext-author-dx.md](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/v0_20_1/m-ext-author-dx.md). See also [discussion #23](https://github.com/arniwesth/motoko_agent/discussions/23#discussioncomment-16952745) for the full plan.

## Test plan

- [x] `bash -n scripts/sync-extension-packages.sh` — syntax check
- [ ] Once merged: `fix_context_mode_extension` branch CI flips to green

## Followup (separate PR)

The `motoko_ext_abi 2.2.0` / `motoko_ext_compaction_ai 0.2.0` / deepseek-v4 context_limit threading work has been parked on `parked/abi-2.2.0-context-limit-thread` (commit `229bc59`) and will land in a separate PR once the dependent ext packages (test_dummy/omnigraph/etc.) finish republishing against abi 2.2.0. Holding it here would block this CI fix on the cascade completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)