### PR TITLE
config: add ollama profile for local Ollama eval rig

### DIFF
--- a/.motoko/config/ollama/config.json
+++ b/.motoko/config/ollama/config.json
@@ -1,0 +1,38 @@
+{
+  "agent": {
+    "model": "ollama/qwen3.5:35b-a3b-mxfp8",
+    "workdir": ".",
+    "max_steps": 50,
+    "step_delay_ms": 0,
+    "max_retries": 3,
+    "retry_base_ms": 1000,
+    "retry_cap_ms": 30000,
+    "semi_formal_verifier_mode": false,
+    "system_prompt": "",
+    "openai_base_url": "http://localhost:11434/v1",
+    "ai_options_json": "{\"enable_thinking\":false}"
+  },
+  "backend": {
+    "mode": "external_http",
+    "url": "http://127.0.0.1:8080",
+    "port": 8080,
+    "auto_start": true,
+    "command": "bun",
+    "args": ["src/tui/src/env-server-main.ts"],
+    "startup_timeout_ms": 5000
+  },
+  "tools": {
+    "hybrid": true,
+    "ohmy_pi": false,
+    "snippet_caps": ["IO", "FS", "Process"],
+    "delegated_timeout_ms": 30000,
+    "delegated_poll_ms": 100,
+    "delegated_timeout_slack_ms": 5000,
+    "edit_mode": "hashline"
+  },
+  "extensions": {
+    "order": ["compaction_ai", "context_mode"],
+    "strict": false
+  },
+  "verification": {}
+}


### PR DESCRIPTION
## Summary

- Adds `.motoko/config/ollama/config.json` pointing at `http://localhost:11434/v1` (Ollama 0.24 OpenAI-compat API on the M4 Max eval rig)
- `enable_thinking: false` — Ollama does not forward `chat_template_kwargs` (vLLM-specific); sending thinking params causes a 400
- Drops `exa_search` and `omnigraph` extensions — both make outbound HTTP calls that break eval hermeticity for local runs
- `edit_mode: hashline` retained — degrades gracefully if tool-call JSON is malformed

## Context

Part of M-MOTOKO-LOCAL-OLLAMA (ailang v0.24.0). The AILANG eval harness passes `MOTOKO_CONFIG=ollama` to motoko via a new `motoko_profile` field in `models.yml`. The paired ailang-side changes add the `motoko-local-qwen3-5-35b-a3b-mxfp8` entry and wire `MotokoProfile` through `ModelConfig → task.Metadata → MOTOKO_CONFIG` env var.

## Test plan

- [ ] `ailang eval-suite --models motoko-local-qwen3-5-35b-a3b-mxfp8 --tier smoke` on the M4 Max rig with Ollama running at localhost:11434
- [ ] Confirm session JSONL is emitted (motoko started and completed its loop)
- [ ] Confirm no `OPENROUTER_API_KEY` required

🤖 Generated with [Claude Code](https://claude.com/claude-code)