### PR TITLE
feat(loop): bounded persistence nudge on premature disengagement (M-MOTOKO-PERSIST-NUDGE)

### DIFF
--- a/src/core/agent_loop_v2.ail
+++ b/src/core/agent_loop_v2.ail
@@ -872,6 +872,59 @@ func dp7_gate(rt: ExtRuntime, workdir: string, step_idx: int, session_id: string
   }
 }
 
+-- M-MOTOKO-PERSIST-NUDGE: bounded loop-persistence at the NoDecision boundary.
+-- Root cause (2026-06-18 A/B transcripts): on local models the agent often
+-- DISENGAGES after 0–1 tool calls WITHOUT writing a solution — either answering
+-- in prose (0 tool calls) or making one inspect call (e.g. `cat solution.ail`)
+-- and stopping. The loop then finalizes at NoDecision. These helpers let the loop
+-- inject a bounded nudge to keep going instead. Off by default (MOTOKO_PERSIST_
+-- RETRIES=0); opt-in for A/B so the rotation is unchanged until validated.
+
+-- Marker embedded in injected nudges so we can count them from history alone
+-- (no new loop_v2 state to thread through its 16 recursive call sites).
+func persist_nudge_marker() -> string { "[motoko-persist-nudge]" }
+
+-- How many persistence nudges are allowed this run (MOTOKO_PERSIST_RETRIES,
+-- default 0 = feature off).
+func persist_retries_budget() -> int ! {Env} {
+  match _stringToInt(trim(getEnvOr("MOTOKO_PERSIST_RETRIES", "0"))) {
+    Some(n) => if n > 0 then n else 0,
+    None => 0
+  }
+}
+
+-- Count nudges already injected (user messages carrying the marker) so we never
+-- exceed the budget — the count IS the persistence state, read from history.
+func count_persist_nudges(msgs: [Message]) -> int {
+  match msgs {
+    [] => 0,
+    m :: rest => {
+      let here = if m.role == "user" && contains(m.content, persist_nudge_marker()) then 1 else 0;
+      here + count_persist_nudges(rest)
+    }
+  }
+}
+
+func tool_calls_have_writefile(calls: [ToolCall]) -> bool {
+  match calls {
+    [] => false,
+    c :: rest => if c.name == "WriteFile" then true else tool_calls_have_writefile(rest)
+  }
+}
+
+-- True once the model has attempted ANY WriteFile this run — if so it is engaged
+-- with producing a solution, so we let it finalize/fail on its own (don't nudge).
+-- Both disengagement modes (0 calls / 1 inspect call) have zero WriteFile, so
+-- this gates the nudge precisely to the premature-stop case.
+func any_writefile_attempt(msgs: [Message]) -> bool {
+  match msgs {
+    [] => false,
+    m :: rest =>
+      if tool_calls_have_writefile(m.tool_calls) then true
+      else any_writefile_attempt(rest)
+  }
+}
+
 func loop_v2(
   rt: ExtRuntime,
   task: string,
@@ -1140,6 +1193,28 @@ func loop_v2(
                   loop_v2(rt, task, env_url, hybrid_tools, budget, model, next_msgs, workdir, step_idx + 1, step_budget - 1, ohmy_pi, max_cost_millicents, cost_rates, new_totals, next_provider, session_id, started_at_ms)
                 },
                 NoDecision => {
+                  -- M-MOTOKO-PERSIST-NUDGE: the model stopped (finish_reason !=
+                  -- tool_calls) and no extension claimed the prose. If it never
+                  -- wrote a solution and we have nudge budget left, keep the loop
+                  -- ALIVE with a bounded nudge instead of finalizing — this is the
+                  -- backlog-#1 disengagement fix (off unless MOTOKO_PERSIST_RETRIES>0).
+                  let persist_budget = persist_retries_budget();
+                  let nudges_used = count_persist_nudges(msgs_with_assistant);
+                  if persist_budget > 0 && nudges_used < persist_budget && not any_writefile_attempt(msgs_with_assistant) then {
+                    let _ = emit_event(session_id, "persist_nudge", [
+                      kv("step", jnum(_int_to_float(step_idx))),
+                      kv("nudge_num", jnum(_int_to_float(nudges_used + 1))),
+                      kv("budget", jnum(_int_to_float(persist_budget)))
+                    ]);
+                    let nudge_msg: Message = {
+                      role: "user",
+                      content: "${persist_nudge_marker()} You stopped without writing a solution file. Do NOT answer in prose — use the WriteFile tool to save your complete solution to the file the task specifies, then keep going (read errors, edit, re-run) until it compiles and runs.",
+                      tool_calls: [],
+                      tool_call_id: ""
+                    };
+                    let next_msgs = msgs_with_assistant ++ [nudge_msg];
+                    loop_v2(rt, task, env_url, hybrid_tools, budget, model, next_msgs, workdir, step_idx + 1, step_budget - 1, ohmy_pi, max_cost_millicents, cost_rates, new_totals, next_provider, session_id, started_at_ms)
+                  } else {
                   match dp7_gate(rt, workdir, step_idx, session_id) {
                     None => {
                       -- IMPORTANT: run_summary BEFORE done — see Accept branch
@@ -1156,6 +1231,7 @@ func loop_v2(
                       let next_msgs = msgs_with_assistant ++ [retry_msg];
                       loop_v2(rt, task, env_url, hybrid_tools, budget, model, next_msgs, workdir, step_idx + 1, step_budget - 1, ohmy_pi, max_cost_millicents, cost_rates, new_totals, next_provider, session_id, started_at_ms)
                     }
+                  }
                   }
                 }
               }

--- a/src/tui/src/runtime-process.ts
+++ b/src/tui/src/runtime-process.ts
@@ -316,6 +316,11 @@ export class RuntimeProcess {
       MOTOKO_HEADLESS:
         process.env.MOTOKO_HEADLESS ??
         (process.stdin.isTTY ? "" : "1"),
+      // M-MOTOKO-PERSIST-NUDGE: forward the loop-persistence retry budget so
+      // agent_loop_v2.ail's NoDecision branch can read it. Without this the
+      // explicit env allowlist scrubs it and the feature is silently off —
+      // same gotcha as MOTOKO_REPO / the pricing vars below. Empty = off.
+      MOTOKO_PERSIST_RETRIES: process.env.MOTOKO_PERSIST_RETRIES ?? "",
       // M-MOTOKO-EVAL-HARNESS-HARDENING gap #6 (2026-05-08): forward
       // MOTOKO_REPO so the AILANG runtime can fall back to the fork's
       // bundled profile (.motoko/config/<profile>) when WORKDIR is a


### PR DESCRIPTION
## Problem

On local models (qwen3.6 via Ollama), the agent frequently **disengages after 0–1 tool calls without writing a solution**, and `loop_v2` finalizes. Two shapes, both confirmed from request/transcript captures:

- **Mode A** (`1 turn, 0 tool calls`): the model answers in **prose** and never calls `WriteFile`.
- **Mode B** (`2 turns, 1 tool call`): the model makes one inspect call (e.g. `cat solution.ail`), sees nothing, and **stops** — never writing.

On the same model/benchmarks, the reference harness (pi) grinds ~33 turns on these failures; motoko gives up at ~2. A `ContinueWithFeedback` persistence mechanism already exists in the loop, but no extension in the lean local profile fires it — so prose-without-write falls through `dispatch_solver_candidate → NoDecision → done`. The gap is a missing **trigger**, not a missing mechanism.

## Change

A bounded built-in persistence nudge at the `NoDecision` boundary in `agent_loop_v2.ail`. When the model stops (`finish_reason != "tool_calls"`), no extension claims the prose, **no `WriteFile` has been attempted this run**, and nudge budget remains → inject a user-role nudge ("use WriteFile, then keep going until it compiles and runs") and recurse, instead of finalizing.

Key design choice: **no new `loop_v2` state threaded through its 16 recursive call sites.** The persistence state is read from the already-threaded `msgs` history:
- `any_writefile_attempt(msgs)` — has the model tried a `WriteFile` yet? (if so, it's engaged — don't nudge)
- `count_persist_nudges(msgs)` — how many nudges already injected (marker-tagged), so we never exceed budget

Gated by **`MOTOKO_PERSIST_RETRIES` (default `0` = off)**; forwarded through the `RuntimeProcess` env allowlist (`runtime-process.ts`) so the AILANG runtime can read it. Distinct from the earlier compel-write guard (a hard one-shot that fired 0/18) — this keeps the loop **alive**, bounded.

## Verification

- `make check_core`: 23/23 type-check; `tsc` clean.
- **Direct run** (`MOTOKO_PERSIST_RETRIES=3`, prose-only task): `persist_nudge` fired once and converted a 0-tool-call disengagement into **17 tool calls**, then `any_writefile_attempt` blocked further nudges (bounded). Confirms env propagation + firing + the bound.
- **A/B** (motoko-local-qwen3.6, 6 flaky AILANG benchmarks ×3, off vs `=3`):

  | benchmark | off | on |
  |---|---|---|
  | cli_args | 2/3 | 3/3 |
  | config_file_parser | 1/3 | 2/3 |
  | json_transform | 2/3 | 3/3 |
  | lambda_calc | 2/3 | 3/3 |
  | json_parse | 3/3 | 3/3 |
  | graph_bfs | 1/3 | 0/3 |
  | **TOTAL** | **11/18 (61%)** | **14/18 (78%)** |

  Net **+3/18**; 4 of 6 improved, 1 regressed (graph_bfs — the perennial 0/1 floor, noise at n=3). `config_file_parser` is the clearest causal win: the nudge drove it 4.5→21 turns and it converted.

## Notes

- **Off by default** — opt-in via `MOTOKO_PERSIST_RETRIES`. n=3 here; recommend validating at rotation scale before any default-on.
- `dist/` is gitignored; `run-agent.sh` runs `src/` directly via bun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
