### PR TITLE
feat(runtime): allowlist AILANG_OLLAMA_MAX_TOKENS (per-model output budget for reasoning models)

### DIFF
--- a/src/tui/src/runtime-process.ts
+++ b/src/tui/src/runtime-process.ts
@@ -334,6 +334,14 @@ export class RuntimeProcess {
       // moved out into separate packages without a corresponding launcher
       // wiring.
       MOTOKO_PROFILE_DIR: path.resolve(workdir, ".motoko", "config", profile),
+      // M-OLLAMA-PER-MODEL-MAX-TOKENS: forward the per-model output budget so the
+      // AILANG runtime's ollama /v1 path (resolveOllamaMaxTokens) uses the model's
+      // declared max_output_tokens instead of the 4096 std/ai default. Qwen3.6
+      // reasons thousands of tokens before the tool call and truncates
+      // (finish_reason=length) at 4096 → 0 tool calls (disengagement). Without this
+      // allowlist entry the explicit childEnv whitelist drops it — same gotcha as
+      // MOTOKO_REPO / the pricing vars. Empty = the AILANG-side 16384 floor applies.
+      AILANG_OLLAMA_MAX_TOKENS: process.env.AILANG_OLLAMA_MAX_TOKENS ?? "",
       // M-MOTOKO-EVAL-HARNESS-HARDENING M5 follow-up (2026-05-08): forward
       // pricing env vars set by the AILANG adapter from Task.Budget. Without
       // this, the AILANG-side fix (load_cost_rates reads these env vars) is


### PR DESCRIPTION
## Problem

The `RuntimeProcess` spawn passes the AILANG runtime an **explicit env allowlist** (`childEnv`). The AILANG eval adapter forwards the model's declared output budget (`models.yml` `max_output_tokens`) as `AILANG_OLLAMA_MAX_TOKENS`, but the allowlist **scrubs it**, so the AILANG runtime's ollama `/v1` path falls back to the `std/ai` default of **4096**.

That truncates Qwen3.6 specifically: it's a heavy reasoner (~4k+ tokens of `<think>` before the tool call), so at 4096 it hits `finish_reason=length` and gets cut off **before** emitting the tool call → 0 tool calls → the run looks like a "no-op" disengagement. Wire-proven on the AILANG side: 11/14 disengaged turns were `finish_reason=length`; raising the budget to 16384 flips them to engaged (21%→79% on the disengaging benchmarks).

## Change

Add `AILANG_OLLAMA_MAX_TOKENS` to the `childEnv` allowlist (one line), forwarding it like `MOTOKO_REPO` and the pricing vars. With it, the AILANG runtime's `resolveOllamaMaxTokens` uses the model's *declared* value (32768 for qwen3.6); without it, AILANG's 16384 floor still applies — so this is purely "use the precise per-model value instead of the floor."

Same pattern as the existing `MOTOKO_REPO` / `MOTOKO_COST_*` forwarding.

## Verification
- `tsc` clean.
- AILANG side (separate, on `sunholo-data/ailang` `dev`): `Task.MaxOutputTokens` ← registry, `motoko.go` sets `AILANG_OLLAMA_MAX_TOKENS`, unit-tested. End-to-end (motoko's wire request carrying 32768) is verifiable via the AILANG HTTP-wire logger once this lands.

## Notes
- `dist/` is gitignored; `run-agent.sh` runs `src/` directly via bun.
- No behavior change when the env is unset (falls through to the AILANG floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
