### PR TITLE
Fixed clickstack issue

### DIFF
--- a/.agent/prs/mot-11-fix-clickstack-startup-401.md
+++ b/.agent/prs/mot-11-fix-clickstack-startup-401.md
@@ -1,0 +1,85 @@
+# Fix Spurious ClickStack 401 at Startup
+
+Base branch: `origin/main`
+
+## Summary
+
+Launching Motoko with the `observability` profile printed a `traces export:
+failed to send ... 401 Unauthorized (missing or empty authorization header)`
+error on every startup — even when a valid `CLICKSTACK_INGESTION_KEY` was set in
+`.env`. The error was misleading: the key was present and valid, but it never
+reached the AILANG trace exporter.
+
+Root cause: **bun's `execSync` does not propagate runtime-mutated `process.env`
+to child processes** — only the snapshot captured at process start. The flow
+was:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT` is injected into the container env by
+  docker-compose *at start*, so it is in bun's snapshot and the child `ailang`
+  version probe sees it and attempts trace export.
+- `synthesizeClickStackOtelHeaders()` derives
+  `OTEL_EXPORTER_OTLP_HEADERS=authorization=$CLICKSTACK_INGESTION_KEY` *at
+  runtime*, so it is **not** in the snapshot and never reaches the probe.
+- Result: the probe exports traces with no auth header → ClickStack returns 401
+  on every launch.
+
+(The long-running agent runtime in `runtime-process.ts` was unaffected because
+it builds its child env explicitly; the visible 401 came from the startup
+version probe.)
+
+## Changes
+
+- Pass `env: process.env` to the `ailang` version-probe `execSync` in
+  `src/tui/src/index.ts` so bun forwards the runtime-derived OTLP auth header to
+  the child. With a valid key present, this eliminates the 401 entirely.
+- Add a "skip export + show hint" path for when ClickStack tracing is enabled
+  but no ingestion key resolves: Motoko now disables trace export for the run
+  and prints a single actionable hint instead of letting the runtime spam raw
+  401s. Implemented via three helpers:
+  - `clickStackAuthHeaderPresent()` — detects whether an OTLP `authorization`
+    header is configured (directly or synthesized from
+    `CLICKSTACK_INGESTION_KEY`).
+  - `disableOtelExport()` — deletes `OTEL_EXPORTER_OTLP_ENDPOINT`,
+    `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, and `MOTOKO_OTEL` from `process.env`.
+    Removing the endpoint is the *only* reliable way to stop AILANG from
+    exporting — `AILANG_TRACE=off` / `AILANG_NO_TRACE=1` do **not** prevent it,
+    since the exporter is initialized on endpoint presence alone.
+  - `warnClickStackTracingDisabled()` — emits the one-line hint pointing at
+    `CLICKSTACK_INGESTION_KEY` / `OTEL_EXPORTER_OTLP_HEADERS` /
+    `clickstack.enabled=false`.
+- Document the `standard` vs `deep` trace tiers (and `off`), tier precedence,
+  aliases, and the `AILANG_TRACE_MAX_SPANS` interaction in
+  `deploy/clickstack/README.md`.
+
+## User Impact
+
+- With a valid `CLICKSTACK_INGESTION_KEY` set, the startup 401 is gone and
+  traces authenticate and export normally.
+- With no key set, the run no longer spams cryptic 401 / `Trace:` lines. Instead
+  it prints one clear hint explaining tracing is disabled for this run and how
+  to enable it, e.g.:
+
+  ```
+  Motoko: ClickStack tracing is enabled but no ingestion key is set — tracing is disabled for this run (http://clickstack:4318 would reject it with 401).
+    Fix: add CLICKSTACK_INGESTION_KEY=<key> to .env (find it in the ClickStack UI → Team Settings → API Keys),
+         or set OTEL_EXPORTER_OTLP_HEADERS='authorization=<key>' directly, or set clickstack.enabled=false to silence this.
+  ```
+
+- `deploy/clickstack/README.md` now explains what `AILANG_TRACE=deep` buys
+  (per-call `eval.function.*` and per-op `eval.effect.*` spans, ~2× overhead)
+  versus the default `standard` structural spans.
+
+## Verification
+
+- `bun run build` (tsc) from `src/tui` — passes.
+- Key present (`.env` has `CLICKSTACK_INGESTION_KEY`): startup emits no
+  `401` / `traces export` / `Trace:` lines.
+- Key absent (temporarily removed from `.env`): startup prints the
+  `tracing is disabled for this run` hint and no 401 / `Trace:` lines.
+- Confirmed via direct `ailang run` that only removing
+  `OTEL_EXPORTER_OTLP_ENDPOINT` silences export — `AILANG_TRACE=off` and
+  `AILANG_NO_TRACE=1` still 401 with the endpoint set.
+
+Note: pre-existing lint diagnostics in the delegated-exec code
+(`index.ts` "unreachable code" / unused `status`) are unrelated to this change
+and left untouched.

--- a/.agent/summaries/2026-06-20-clickstack-startup-401.md
+++ b/.agent/summaries/2026-06-20-clickstack-startup-401.md
@@ -1,0 +1,99 @@
+# 2026-06-20 ClickStack Startup 401 Investigation And Fix
+
+## Context
+
+Branch: `arniwesth/mot-11-fix-clickstack-wrongly-reported-issue-at-startup`
+(base `origin/main`).
+
+The user reported that `make run` with the `observability` profile printed on
+every startup:
+
+```
+Trace: standard (set AILANG_TRACE=deep or --trace-tier deep for per-call spans)
+2026/06/20 ... traces export: failed to send to http://clickstack:4318/v1/traces: 401 Unauthorized (missing or empty authorization header: Authorization)
+```
+
+The initial ask was simply "Motoko should write out a short hint on how to solve
+it." The session turned into a deeper diagnosis: the error was misleading and a
+real propagation bug was hiding behind it.
+
+## Investigation
+
+The diagnosis went through several wrong turns before landing on the root cause:
+
+1. **First hypothesis (proactive hint).** Added a pre-flight warning when
+   ClickStack was enabled but no `OTEL_EXPORTER_OTLP_HEADERS` was set. It never
+   fired — established that the message comes from the AILANG runtime's
+   inherited stderr, which Motoko cannot intercept after the fact.
+2. **Traced the launch flow.** `make run` → `scripts/run-agent.sh` →
+   `bun src/tui/src/index.ts` (runs the TS source directly, not `dist`). The
+   startup 401 comes from the `ailang run --entry print_version` version probe
+   (`index.ts` ~line 740), not from the long-running agent runtime.
+3. **Found existing key infrastructure.** `.env` already contained a valid
+   `CLICKSTACK_INGESTION_KEY`, and `synthesizeClickStackOtelHeaders()` turns it
+   into `OTEL_EXPORTER_OTLP_HEADERS=authorization=<key>` at runtime. So the hint
+   gating (header-present check) was being satisfied — yet ClickStack still
+   401'd. The key was the wrong thing to blame.
+4. **Verified the key is valid.** Running `ailang run` directly with the header
+   in the environment → no 401. Without it → 401. So the key worked; it just was
+   not reaching the exporter.
+5. **Root cause — bun env snapshot.** Instrumented the TUI and confirmed
+   `process.env.OTEL_EXPORTER_OTLP_HEADERS` was correctly set right before the
+   `execSync` probe, yet the child still 401'd. A minimal repro nailed it:
+   **bun's `execSync` does not propagate runtime-mutated `process.env` to
+   children** — only the snapshot captured at process start.
+   - `OTEL_EXPORTER_OTLP_ENDPOINT` is injected by docker-compose *at start* →
+     in bun's snapshot → child sees it → attempts export.
+   - `OTEL_EXPORTER_OTLP_HEADERS` is set *at runtime* → not in the snapshot →
+     child sends no auth header → 401.
+   - Passing `env: process.env` explicitly to `execSync` fixes propagation.
+6. **Which knob silences AILANG export.** Tested empirically: `AILANG_TRACE=off`
+   and `AILANG_NO_TRACE=1` do **not** stop trace export — AILANG initializes its
+   OTLP exporter purely on `OTEL_EXPORTER_OTLP_ENDPOINT` being set. Only removing
+   the endpoint reliably silences it.
+7. **AILANG trace tiers.** Read `ailang/internal/trace/options.go` and
+   `otel_emitter.go` to answer a follow-up question about `standard` vs `deep`.
+
+## Changes (final state on branch)
+
+- `src/tui/src/index.ts`:
+  - Pass `env: process.env` to the version-probe `execSync` so the runtime-set
+    OTLP auth header reaches the child. Eliminates the 401 when a valid key is
+    present.
+  - "Skip export + show hint" path (the behavior the user chose) when ClickStack
+    is enabled but no key resolves: `clickStackAuthHeaderPresent()`,
+    `disableOtelExport()` (deletes `OTEL_EXPORTER_OTLP_ENDPOINT`,
+    `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `MOTOKO_OTEL`), and
+    `warnClickStackTracingDisabled()` (one-line actionable hint). No more raw
+    401 spam in the no-key case.
+- `deploy/clickstack/README.md`: documented the `standard` vs `deep` (and `off`)
+  trace tiers, precedence, aliases, and `AILANG_TRACE_MAX_SPANS` interaction.
+- `.agent/prs/mot-11-fix-clickstack-startup-401.md`: PR description for the
+  branch.
+
+## Verification
+
+- `bun run build` (tsc) from `src/tui` — passes.
+- Key present: no `401` / `traces export` / `Trace:` lines at startup.
+- Key absent (temporarily removed from `.env`, then restored): prints the
+  `tracing is disabled for this run` hint, no 401 / `Trace:` lines.
+
+## Key Takeaways
+
+- **bun gotcha:** mutating `process.env` at runtime does *not* affect
+  `execSync` / `spawnSync` children unless `env: process.env` is passed
+  explicitly. Any future child spawn relying on a runtime-set var has the same
+  trap. (The agent runtime in `runtime-process.ts` was already safe because it
+  builds its child env explicitly.)
+- **AILANG OTLP export is gated on `OTEL_EXPORTER_OTLP_ENDPOINT` presence, not
+  on `AILANG_TRACE`.** To disable export, remove the endpoint; the trace tier
+  only controls span granularity.
+- The user-facing 401 originated from the startup version probe, not the agent
+  loop.
+
+## Follow-ups / Notes
+
+- Pre-existing lint diagnostics in the delegated-exec code (`index.ts`
+  "unreachable code" / unused `status`) are unrelated and were left untouched.
+- The branch's single commit folds the trace-tier README docs in with the 401
+  fix; could be split if a cleaner history is wanted.

--- a/deploy/clickstack/README.md
+++ b/deploy/clickstack/README.md
@@ -41,6 +41,31 @@ The Motoko launcher derives
 OTLP headers variable is not already set. Existing explicit
 `OTEL_EXPORTER_OTLP_HEADERS` values still take precedence.
 
+## Trace tiers (`standard` vs `deep`)
+
+`AILANG_TRACE` selects how much detail the emitter writes. On startup AILANG
+prints e.g. `Trace: standard (set AILANG_TRACE=deep or --trace-tier deep for
+per-call spans)`. There are three tiers — `off`, `standard` (default), and
+`deep`:
+
+| Tier | Spans emitted | Use for |
+|---|---|---|
+| `off` | None. | Disabling tracing (also `AILANG_NO_TRACE=1`). |
+| `standard` (default) | Coarse, structural spans only: module, top-level effect, coordinator, executor, compile, and task/chain-linked spans. **Skips** per-call function spans and nested effect spans (only top-level effects, `depth <= 1`). | Normal runs — a high-level skeleton of what happened. |
+| `deep` | Everything `standard` emits **plus** one `eval.function.*` span per call (with name, depth, args, result, duration) and one `eval.effect.<Effect>.<Op>` span per effect op at any depth. | Profiling or capturing detailed training data. ~2× overhead. |
+
+Precedence: `--trace-tier` flag > `AILANG_TRACE` env > legacy `AILANG_NO_TRACE=1`
+> default (`standard`). Aliases: `deep`/`full`/`all`, `standard`/`default`/`""`,
+`off`/`none`/`disabled`.
+
+```bash
+export AILANG_TRACE=deep   # per-call function + effect spans
+```
+
+Because `deep` can emit a span per function call, it is most likely to hit the
+per-trace span budget (`AILANG_TRACE_MAX_SPANS`, default 500); overflow is
+truncated.
+
 If OTLP HTTP on `4318` returns timeouts from `/v1/traces` or `/v1/metrics`,
 lower trace volume while debugging:
 

--- a/src/tui/src/index.ts
+++ b/src/tui/src/index.ts
@@ -257,6 +257,18 @@ function applyClickStackProfileConfig(
   protectedKeys: Set<string>,
 ): void {
   if (!clickstack?.enabled) return;
+  // ClickStack/HyperDX rejects OTLP ingestion without an authorization header,
+  // so without a key the AILANG runtime would emit `traces export: failed to
+  // send ... 401 (missing or empty authorization header)` on every span. The
+  // header is derived from CLICKSTACK_INGESTION_KEY by
+  // synthesizeClickStackOtelHeaders() (already run by this point). If no key is
+  // available we know export is doomed, so we skip it entirely and print a
+  // single actionable hint instead of letting the runtime spam 401s.
+  if (!clickStackAuthHeaderPresent()) {
+    disableOtelExport();
+    warnClickStackTracingDisabled(clickstack.endpoint);
+    return;
+  }
   setFromProfile(protectedKeys, "MOTOKO_OTEL", "1");
   setFromProfile(protectedKeys, "OTEL_EXPORTER_OTLP_ENDPOINT", clickstack.endpoint);
   setFromProfile(protectedKeys, "OTEL_EXPORTER_OTLP_PROTOCOL", clickstack.protocol);
@@ -265,6 +277,40 @@ function applyClickStackProfileConfig(
   setFromProfile(protectedKeys, "AILANG_TRACE_MAX_SPANS", clickstack.traceMaxSpans);
   setFromProfile(protectedKeys, "OTEL_METRICS_EXPORTER", clickstack.metricsExporter);
   setFromProfile(protectedKeys, "OTEL_EXPORTER_OTLP_TIMEOUT", clickstack.timeoutMs);
+}
+
+// True when an OTLP authorization header is configured (directly, or
+// synthesized from CLICKSTACK_INGESTION_KEY by synthesizeClickStackOtelHeaders).
+function clickStackAuthHeaderPresent(): boolean {
+  const headers =
+    process.env.OTEL_EXPORTER_OTLP_HEADERS ??
+    process.env.OTEL_EXPORTER_OTLP_TRACES_HEADERS ??
+    "";
+  return /authorization\s*=/i.test(headers);
+}
+
+// Prevent every AILANG child (the version probe and the agent runtime) from
+// attempting trace export. AILANG only initializes its OTLP exporter when
+// OTEL_EXPORTER_OTLP_ENDPOINT is set — and crucially AILANG_TRACE=off does NOT
+// stop it, only removing the endpoint does. The endpoint is injected into the
+// process env by docker-compose (observability stack), so deleting it here is
+// the only reliable way to silence export. The version probe inherits
+// process.env directly; the runtime is additionally gated on MOTOKO_OTEL.
+function disableOtelExport(): void {
+  delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+  delete process.env.MOTOKO_OTEL;
+}
+
+// Emit a single, actionable line explaining that tracing is off for this run
+// because no ingestion key was found — replacing the runtime's raw 401 spam.
+function warnClickStackTracingDisabled(endpoint: string | undefined): void {
+  const target = nonEmptyString(endpoint) ?? "the OTLP endpoint";
+  process.stderr.write(
+    `Motoko: ClickStack tracing is enabled but no ingestion key is set — tracing is disabled for this run (${target} would reject it with 401).\n` +
+      `  Fix: add CLICKSTACK_INGESTION_KEY=<key> to .env (find it in the ClickStack UI → Team Settings → API Keys),\n` +
+      `       or set OTEL_EXPORTER_OTLP_HEADERS='authorization=<key>' directly, or set clickstack.enabled=false to silence this.\n`,
+  );
 }
 
 function applyToolProfileConfig(
@@ -717,7 +763,13 @@ async function main(): Promise<void> {
   try {
     brainVersion = execSync(
       "ailang run --entry print_version --caps IO src/core/version.ail | tail -1",
-      { cwd: projectRoot, timeout: 15000 },
+      // env: process.env is REQUIRED — bun's execSync does not propagate
+      // runtime-mutated process.env to children, only the snapshot captured at
+      // process start. synthesizeClickStackOtelHeaders() sets
+      // OTEL_EXPORTER_OTLP_HEADERS at runtime, so without this the probe runs
+      // the AILANG trace exporter with no auth header and ClickStack rejects it
+      // with `401 ... missing or empty authorization header` on every launch.
+      { cwd: projectRoot, timeout: 15000, env: process.env },
     ).toString().trim();
   } catch {
     // Runtime not available (ailang not on PATH, etc.) — banner shows "unknown".


### PR DESCRIPTION
# Fix Spurious ClickStack 401 at Startup

Base branch: `origin/main`

## Summary

Launching Motoko with the `observability` profile printed a `traces export:
failed to send ... 401 Unauthorized (missing or empty authorization header)`
error on every startup — even when a valid `CLICKSTACK_INGESTION_KEY` was set in
`.env`. The error was misleading: the key was present and valid, but it never
reached the AILANG trace exporter.

Root cause: **bun's `execSync` does not propagate runtime-mutated `process.env`
to child processes** — only the snapshot captured at process start. The flow
was:

- `OTEL_EXPORTER_OTLP_ENDPOINT` is injected into the container env by
  docker-compose *at start*, so it is in bun's snapshot and the child `ailang`
  version probe sees it and attempts trace export.
- `synthesizeClickStackOtelHeaders()` derives
  `OTEL_EXPORTER_OTLP_HEADERS=authorization=$CLICKSTACK_INGESTION_KEY` *at
  runtime*, so it is **not** in the snapshot and never reaches the probe.
- Result: the probe exports traces with no auth header → ClickStack returns 401
  on every launch.

(The long-running agent runtime in `runtime-process.ts` was unaffected because
it builds its child env explicitly; the visible 401 came from the startup
version probe.)

## Changes

- Pass `env: process.env` to the `ailang` version-probe `execSync` in
  `src/tui/src/index.ts` so bun forwards the runtime-derived OTLP auth header to
  the child. With a valid key present, this eliminates the 401 entirely.
- Add a "skip export + show hint" path for when ClickStack tracing is enabled
  but no ingestion key resolves: Motoko now disables trace export for the run
  and prints a single actionable hint instead of letting the runtime spam raw
  401s. Implemented via three helpers:
  - `clickStackAuthHeaderPresent()` — detects whether an OTLP `authorization`
    header is configured (directly or synthesized from
    `CLICKSTACK_INGESTION_KEY`).
  - `disableOtelExport()` — deletes `OTEL_EXPORTER_OTLP_ENDPOINT`,
    `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, and `MOTOKO_OTEL` from `process.env`.
    Removing the endpoint is the *only* reliable way to stop AILANG from
    exporting — `AILANG_TRACE=off` / `AILANG_NO_TRACE=1` do **not** prevent it,
    since the exporter is initialized on endpoint presence alone.
  - `warnClickStackTracingDisabled()` — emits the one-line hint pointing at
    `CLICKSTACK_INGESTION_KEY` / `OTEL_EXPORTER_OTLP_HEADERS` /
    `clickstack.enabled=false`.
- Document the `standard` vs `deep` trace tiers (and `off`), tier precedence,
  aliases, and the `AILANG_TRACE_MAX_SPANS` interaction in
  `deploy/clickstack/README.md`.

## User Impact

- With a valid `CLICKSTACK_INGESTION_KEY` set, the startup 401 is gone and
  traces authenticate and export normally.
- With no key set, the run no longer spams cryptic 401 / `Trace:` lines. Instead
  it prints one clear hint explaining tracing is disabled for this run and how
  to enable it, e.g.:

  ```
  Motoko: ClickStack tracing is enabled but no ingestion key is set — tracing is disabled for this run (http://clickstack:4318 would reject it with 401).
    Fix: add CLICKSTACK_INGESTION_KEY=<key> to .env (find it in the ClickStack UI → Team Settings → API Keys),
         or set OTEL_EXPORTER_OTLP_HEADERS='authorization=<key>' directly, or set clickstack.enabled=false to silence this.
  ```

- `deploy/clickstack/README.md` now explains what `AILANG_TRACE=deep` buys
  (per-call `eval.function.*` and per-op `eval.effect.*` spans, ~2× overhead)
  versus the default `standard` structural spans.

## Verification

- `bun run build` (tsc) from `src/tui` — passes.
- Key present (`.env` has `CLICKSTACK_INGESTION_KEY`): startup emits no
  `401` / `traces export` / `Trace:` lines.
- Key absent (temporarily removed from `.env`): startup prints the
  `tracing is disabled for this run` hint and no 401 / `Trace:` lines.
- Confirmed via direct `ailang run` that only removing
  `OTEL_EXPORTER_OTLP_ENDPOINT` silences export — `AILANG_TRACE=off` and
  `AILANG_NO_TRACE=1` still 401 with the endpoint set.

Note: pre-existing lint diagnostics in the delegated-exec code
(`index.ts` "unreachable code" / unused `status`) are unrelated to this change
and left untouched.
