### PR TITLE
arniwesth/mot-12-fix-context-mode

### DIFF
--- a/.agent/plans/context_mode/transparent-bash-output-compression.md
+++ b/.agent/plans/context_mode/transparent-bash-output-compression.md
@@ -209,6 +209,65 @@ supports optional record fields or the ABI package introduces a defaulted
 hook-builder abstraction, use that to reduce future ABI churn. For this change,
 assume direct record updates are required.
 
+## Blast Radius
+
+This is not a context-mode-only change. Adding a required hook field to
+`ExtensionHooks` touches the extension ABI, every hook record literal, and both
+tool-dispatch paths.
+
+Expected affected areas:
+
+- ABI package:
+  - `sunholo/motoko_ext_abi/types`
+  - version bump and registry/local dependency updates
+- Root dependency graph:
+  - `ailang.toml`
+  - `ailang.lock`
+  - generated registry imports if ABI package versions or local overrides change
+- In-repo extension packages:
+  - `packages/motoko-ext-context-mode/*`
+  - `packages/motoko_scratchpad/*`
+- Registry extensions currently imported by `src/core/ext/registry_generated.ail`:
+  - test dummy
+  - omnigraph
+  - MCP
+  - exa search
+  - ailang docs
+  - compose
+  - A2A
+  - decision framework
+  - microrag
+  - compaction AI
+  - scratchpad
+- Hand-built test/smoke hook records:
+  - `scripts/smoke_v2_handle.ail`
+  - `scripts/smoke_v2_policy_denial.ail`
+  - `scripts/smoke_v2_pending.ail`
+  - `scripts/smoke_v2_pending_full_loop.ail`
+  - `src/core/test/stub_step.ail`
+  - inline tests in `src/core/ext/runtime.ail`
+- Core runtime:
+  - `src/core/ext/types.ail`
+  - `src/core/ext/runtime.ail`
+  - `src/core/tool_envelope_dispatch.ail`
+  - `src/core/agent_loop_v2.ail`
+  - `src/core/tool_dispatch_adapter.ail` if a structured native-result helper is
+    added beside `dispatch_one`
+- Observability/UI:
+  - TUI and session log readers should continue to parse native `BashExec` JSON
+    with added `context_mode` fields.
+  - Trace event names must not collide with existing `native_tool_*` events.
+
+High-risk compatibility points:
+
+- Every existing `ExtensionHooks` literal must compile after the ABI bump.
+- Native `BashExec` JSON shape must remain backward-compatible.
+- Tool-call correlation IDs must remain unchanged.
+- The v2 delegated-deferred path must not accidentally run result hooks until it
+  has real completed delegated results.
+- `Trace` must not leak into the extension ABI unless AILANG MCP docs and local
+  compiler/runtime support it as a stable effect.
+
 ## Dispatch Semantics
 
 1. Existing policy hooks run first.

--- a/.agent/plans/context_mode/transparent-bash-output-compression.md
+++ b/.agent/plans/context_mode/transparent-bash-output-compression.md
@@ -41,17 +41,28 @@ The core boundary should remain:
 
 ## Proposed ABI
 
-Add a narrow post-result hook to `ExtensionHooks`.
+Add a narrow post-result hook to `ExtensionHooks`. The hook should operate on
+the model-visible native result payload, not on a `ToolResultEnvelope` wrapper
+that would force native tools into the extension-result JSON shape.
 
 ```ail
+import std/json (Json)
+
+export type ToolResultFrame = {
+  tool_call_id: string,
+  tool: string,
+  exit_code: int,
+  content: Json
+}
+
 export type ToolResultDecision
   = Keep
-  | Replace(ToolResultEnvelope)
+  | Replace(ToolResultFrame)
 
 export type ExtensionHooks = {
   ...
   result_tools: [string],
-  on_tool_result: (ExtCtx, ToolCallEnvelope, ToolResultEnvelope)
+  on_tool_result: (ExtCtx, ToolCallEnvelope, ToolResultFrame)
     -> ToolResultDecision ! {IO, Process, FS, AI, Env, Net, SharedMem, Clock, Stream}
 }
 ```
@@ -63,45 +74,95 @@ start with:
 result_tools: ["BashExec", "RunTests"]
 ```
 
-The hook is called only after a tool has completed and produced a
-`ToolResultEnvelope`.
+The hook is called only after a native tool has completed and produced the same
+JSON payload that would otherwise become the tool-role message content. For
+`BashExec`, that payload is the existing adapter shape:
+
+```json
+{
+  "tool": "BashExec",
+  "cmd": "...",
+  "exit_code": 0,
+  "stdout": "...",
+  "stderr": "...",
+  "truncated": false
+}
+```
+
+This avoids a hidden behavior change where native results would become wrapped
+as `{tool_call_id, tool, exit_code, stdout, stderr, metadata}`.
+
+## ABI Compatibility
+
+`ExtensionHooks` comes from `sunholo/motoko_ext_abi`, and in-repo plus registry
+extensions construct that record directly. Adding required fields is therefore a
+source break for every extension package.
+
+Rollout must be versioned:
+
+1. Bump `sunholo/motoko_ext_abi` and update its exported `ExtensionHooks`.
+2. Update every in-repo extension package and smoke-test hook construction.
+3. Republish or locally override any registry extension used by the active root
+   dependency graph.
+4. Regenerate `src/core/ext/registry_generated.ail` and `ailang.lock`.
+5. Run extension boot verification before landing runtime wiring.
+
+If AILANG later supports optional record fields or defaulted hook builders, use
+that to reduce future ABI churn. For this change, assume direct record updates
+are required.
 
 ## Dispatch Semantics
 
 1. Existing policy hooks run first.
 2. Existing handle hooks run next.
 3. If an extension returns `Handled`, core converts that result to the tool-role
-   message as it does today.
+   message as it does today. MVP result hooks do not post-process extension-
+   handled results.
 4. If all extensions delegate, core runs the normal native or delegated backend.
-5. Core converts the backend result into a `ToolResultEnvelope`.
+5. For native backend results, core converts the backend result into the existing
+   model-visible JSON payload and a `ToolResultFrame`.
 6. Core invokes subscribed `on_tool_result` hooks in extension order.
-7. The final envelope becomes the tool-role message.
+7. The final frame content becomes the tool-role message content.
+
+MVP scope: apply result hooks only to completed native results. The current v2
+delegated path returns a synthetic `delegated_backend_not_wired` message, not a
+completed delegated tool result, so there is no real delegated result to
+compress yet. When the ohmy_pi inbox wait path lands, it can construct a
+`ToolResultFrame` from the completed delegated payload and reuse the same hook.
 
 Decision folding:
 
 - `Keep` leaves the current result unchanged.
-- `Replace(next)` replaces the current result and passes it to later result hooks.
+- `Replace(next)` replaces the current frame and passes it to later result hooks.
 - A result hook must not re-enter tool dispatch.
-- If a result hook fails, core should preserve the original result and attach a
-  trace/log event rather than fail the user-visible tool call.
+- A hook must preserve `tool_call_id` and `tool`.
+- If a hook returns a mismatched `tool_call_id` or `tool`, core should ignore the
+  replacement, keep the previous frame, and emit a trace/log event.
 
 ## Context Mode Behavior
 
 For `BashExec` and `RunTests`, `context_mode` should:
 
-1. Inspect `stdout`, `stderr`, `exit_code`, and metadata.
+1. Inspect `stdout`, `stderr`, `exit_code`, and the current JSON content.
 2. If output is below threshold, return `Keep`.
 3. If output exceeds threshold:
-   - store the full output in context-mode/index storage or SharedMem;
+   - store the full output in SharedMem, with optional indexing into
+     context-mode;
    - return a compressed summary in `stdout`/`stderr`;
-   - preserve command, exit code, and truncation metadata;
-   - include a stable lookup key in metadata for later retrieval.
+   - preserve command, exit code, and existing result fields;
+   - include a stable lookup key in the JSON content for later retrieval.
 4. Optionally index durable summaries so later `CtxSearch` can recover facts.
 
-Suggested metadata shape:
+Suggested JSON content shape:
 
 ```json
 {
+  "tool": "BashExec",
+  "cmd": "...",
+  "exit_code": 0,
+  "stdout": "...compressed...",
+  "stderr": "",
+  "truncated": true,
   "context_mode": {
     "compressed": true,
     "snapshot_key": "ctxmode:tool-result:<state>:<tool_call_id>",
@@ -122,18 +183,32 @@ Suggested metadata shape:
 4. Wire `dispatch_tool_result` into both tool execution paths:
    - `src/core/agent_loop_v2.ail`
    - `src/core/tool_envelope_dispatch.ail`
-5. Ensure the hook is called after native/delegated execution and before
+5. In `agent_loop_v2`, avoid the current string-only `dispatch_one` boundary for
+   hookable native tools. Add a helper that returns both:
+   - the existing adapter JSON payload, and
+   - the `ToolResultFrame` used by result hooks.
+6. Ensure the hook is called after native execution and before
    `tool_result_message`.
-6. Emit trace events:
+7. In `tool_envelope_dispatch`, convert the native result payload to a
+   `ToolResultFrame`, run result hooks, then convert the final frame back to the
+   existing `ToolResultEnvelope` convention used by that loopback path:
+   - `stdout: encode(frame.content)`
+   - `stderr: ""`
+   - `metadata: frame.content`
+8. Do not call result hooks for denied calls, pending calls, recursive scratchpad
+   errors, or the current v2 delegated-deferred synthetic message.
+9. Emit trace events from the caller that already has `Trace` in its effect row,
+   not from the pure extension runtime helper if that would widen shared runtime
+   effects:
    - `ext_tool_result_keep`
    - `ext_tool_result_replace`
-   - `ext_tool_result_error`
-7. Add tests for:
+   - `ext_tool_result_invalid_replace`
+10. Add tests for:
    - no subscribed hook leaves results unchanged;
    - subscribed hook can replace `BashExec` output;
    - multiple hooks fold deterministically;
-   - `Handled` extension results can also pass through result hooks, or document
-     if they intentionally do not.
+   - invalid replacement with changed `tool_call_id` or `tool` is ignored;
+   - extension-handled results are not post-processed in the MVP.
 
 ## Context Mode Implementation Steps
 
@@ -141,32 +216,37 @@ Suggested metadata shape:
    - `CONTEXT_MODE_TRANSPARENT_BASH=0|1`
    - `CONTEXT_MODE_TRANSPARENT_MIN_CHARS`
    - `CONTEXT_MODE_TRANSPARENT_INDEX=0|1`
-2. Subscribe to `BashExec` and `RunTests` only when transparent mode is enabled.
-3. Implement output thresholding and compression.
-4. Store full output under a stable per-session key.
-5. Add metadata with the lookup key and original byte counts.
-6. Keep explicit `Ctx*` tools unchanged.
+2. Add a profile/config switch when the runtime config format has a natural
+   place for extension settings. Until then, keep env disabled by default.
+3. Subscribe to `BashExec` and `RunTests` only when transparent mode is enabled.
+4. Implement output thresholding and compression.
+5. Store full output under a stable per-session key.
+6. Add JSON content fields with the lookup key and original byte counts.
+7. Keep explicit `Ctx*` tools unchanged.
 
 ## Safety Rules
 
 - Result hooks must not execute the original tool.
 - Result hooks must not change `tool_call_id`.
-- Result hooks should not change `tool` unless they are converting an internal
-  extension result with a documented reason.
-- Core should preserve the unmodified result on hook failure.
+- Result hooks must not change `tool`.
+- Core should preserve the previous frame on invalid replacement.
+- Result hooks should preserve the native result's required content fields for
+  that tool. For `BashExec`, this means `tool`, `cmd`, `exit_code`, `stdout`,
+  `stderr`, and `truncated`.
 - Compression must preserve enough information for the model to know the command
   succeeded or failed.
+- Full command output may contain secrets. Transparent storage should be disabled
+  by default unless a profile or environment variable explicitly enables it.
 
 ## Open Questions
 
-- Should result hooks apply to extension-handled tool results as well as native
-  results? Applying them uniformly is simpler, but it lets extensions post-process
-  each other.
 - Should the full original output live in SharedMem, context-mode's own index, or
   both?
 - Should transparent compression be profile-controlled rather than env-only?
 - Should `ReadFile` and `Search` be eligible later, or should this first version be
   limited to process-output tools?
+- When delegated ohmy_pi results are fully wired, should they pass through the
+  same result hook before the model sees them?
 
 ## Acceptance Criteria
 
@@ -176,3 +256,6 @@ Suggested metadata shape:
 - Core native dispatch remains the only owner of native process execution.
 - Extensions do not receive a general native dispatch callback in `ExtCtx`.
 - Tests cover unchanged, replaced, and multi-hook result-processing cases.
+- Native `BashExec` result JSON shape remains backward-compatible except for the
+  intentional compressed `stdout`/`stderr` content and added `context_mode`
+  metadata.

--- a/.agent/plans/context_mode/transparent-bash-output-compression.md
+++ b/.agent/plans/context_mode/transparent-bash-output-compression.md
@@ -1,0 +1,178 @@
+# Context Mode Transparent Bash Output Compression Plan
+
+Date: 2026-06-21
+Status: planned
+
+## Problem
+
+PR #58 fixes `context_mode` as an explicit extension tool provider: the model can call
+`CtxSearch`, `ctx_index`, `ctx_execute`, and related tools directly.
+
+That does not solve transparent compression of native `BashExec` output. Today an
+extension sees a tool call before native dispatch through `on_tool_handle`, but it
+cannot let core run the native tool and then transform the result. It can only:
+
+- return `Handled(result)` and fully own execution, or
+- return `Delegate` and lose visibility into the eventual native result.
+
+Adding a generic native execution capability to `ExtCtx` would couple extensions to
+core dispatch internals: backend selection, approval state, tracing, delegated
+execution, cancellation, result formatting, and recursion safety.
+
+## Goal
+
+Enable `context_mode` to transparently compress or index selected native tool
+results, especially `BashExec` and `RunTests`, without making extensions responsible
+for executing native tools.
+
+The core boundary should remain:
+
+- core owns policy, approval, backend selection, execution, tracing, and tool-role
+  message correlation;
+- extensions may inspect and optionally transform completed tool results.
+
+## Non-Goals
+
+- Do not add `run_native_tool` or a general dispatch callback to `ExtCtx`.
+- Do not make `context_mode` reimplement `BashExec`.
+- Do not require the model to switch from `BashExec` to `CtxExecute` for transparent
+  compression.
+- Do not change provider-facing tool call correlation semantics.
+
+## Proposed ABI
+
+Add a narrow post-result hook to `ExtensionHooks`.
+
+```ail
+export type ToolResultDecision
+  = Keep
+  | Replace(ToolResultEnvelope)
+
+export type ExtensionHooks = {
+  ...
+  result_tools: [string],
+  on_tool_result: (ExtCtx, ToolCallEnvelope, ToolResultEnvelope)
+    -> ToolResultDecision ! {IO, Process, FS, AI, Env, Net, SharedMem, Clock, Stream}
+}
+```
+
+`result_tools` is the explicit subscription list. For `context_mode`, this would
+start with:
+
+```ail
+result_tools: ["BashExec", "RunTests"]
+```
+
+The hook is called only after a tool has completed and produced a
+`ToolResultEnvelope`.
+
+## Dispatch Semantics
+
+1. Existing policy hooks run first.
+2. Existing handle hooks run next.
+3. If an extension returns `Handled`, core converts that result to the tool-role
+   message as it does today.
+4. If all extensions delegate, core runs the normal native or delegated backend.
+5. Core converts the backend result into a `ToolResultEnvelope`.
+6. Core invokes subscribed `on_tool_result` hooks in extension order.
+7. The final envelope becomes the tool-role message.
+
+Decision folding:
+
+- `Keep` leaves the current result unchanged.
+- `Replace(next)` replaces the current result and passes it to later result hooks.
+- A result hook must not re-enter tool dispatch.
+- If a result hook fails, core should preserve the original result and attach a
+  trace/log event rather than fail the user-visible tool call.
+
+## Context Mode Behavior
+
+For `BashExec` and `RunTests`, `context_mode` should:
+
+1. Inspect `stdout`, `stderr`, `exit_code`, and metadata.
+2. If output is below threshold, return `Keep`.
+3. If output exceeds threshold:
+   - store the full output in context-mode/index storage or SharedMem;
+   - return a compressed summary in `stdout`/`stderr`;
+   - preserve command, exit code, and truncation metadata;
+   - include a stable lookup key in metadata for later retrieval.
+4. Optionally index durable summaries so later `CtxSearch` can recover facts.
+
+Suggested metadata shape:
+
+```json
+{
+  "context_mode": {
+    "compressed": true,
+    "snapshot_key": "ctxmode:tool-result:<state>:<tool_call_id>",
+    "stdout_original_bytes": 123456,
+    "stderr_original_bytes": 0
+  }
+}
+```
+
+## Core Implementation Steps
+
+1. Extend the extension ABI package with `ToolResultDecision`, `result_tools`, and
+   `on_tool_result`.
+2. Update all in-repo extension registrations to provide defaults:
+   - `result_tools: []`
+   - `on_tool_result: \_ _ _ . Keep`
+3. Add `dispatch_tool_result` to `src/core/ext/runtime.ail`.
+4. Wire `dispatch_tool_result` into both tool execution paths:
+   - `src/core/agent_loop_v2.ail`
+   - `src/core/tool_envelope_dispatch.ail`
+5. Ensure the hook is called after native/delegated execution and before
+   `tool_result_message`.
+6. Emit trace events:
+   - `ext_tool_result_keep`
+   - `ext_tool_result_replace`
+   - `ext_tool_result_error`
+7. Add tests for:
+   - no subscribed hook leaves results unchanged;
+   - subscribed hook can replace `BashExec` output;
+   - multiple hooks fold deterministically;
+   - `Handled` extension results can also pass through result hooks, or document
+     if they intentionally do not.
+
+## Context Mode Implementation Steps
+
+1. Add env-backed config:
+   - `CONTEXT_MODE_TRANSPARENT_BASH=0|1`
+   - `CONTEXT_MODE_TRANSPARENT_MIN_CHARS`
+   - `CONTEXT_MODE_TRANSPARENT_INDEX=0|1`
+2. Subscribe to `BashExec` and `RunTests` only when transparent mode is enabled.
+3. Implement output thresholding and compression.
+4. Store full output under a stable per-session key.
+5. Add metadata with the lookup key and original byte counts.
+6. Keep explicit `Ctx*` tools unchanged.
+
+## Safety Rules
+
+- Result hooks must not execute the original tool.
+- Result hooks must not change `tool_call_id`.
+- Result hooks should not change `tool` unless they are converting an internal
+  extension result with a documented reason.
+- Core should preserve the unmodified result on hook failure.
+- Compression must preserve enough information for the model to know the command
+  succeeded or failed.
+
+## Open Questions
+
+- Should result hooks apply to extension-handled tool results as well as native
+  results? Applying them uniformly is simpler, but it lets extensions post-process
+  each other.
+- Should the full original output live in SharedMem, context-mode's own index, or
+  both?
+- Should transparent compression be profile-controlled rather than env-only?
+- Should `ReadFile` and `Search` be eligible later, or should this first version be
+  limited to process-output tools?
+
+## Acceptance Criteria
+
+- Existing explicit `Ctx*` tools still work.
+- A plain model-emitted `BashExec` call can return compressed output without the
+  model opting into `CtxExecute`.
+- Core native dispatch remains the only owner of native process execution.
+- Extensions do not receive a general native dispatch callback in `ExtCtx`.
+- Tests cover unchanged, replaced, and multi-hook result-processing cases.

--- a/.agent/plans/context_mode/transparent-bash-output-compression.md
+++ b/.agent/plans/context_mode/transparent-bash-output-compression.md
@@ -3,6 +3,15 @@
 Date: 2026-06-21
 Status: planned
 
+## TL;DR
+
+Do not give extensions a general native-tool execution callback through
+`ExtCtx`. Add a narrow post-result hook instead: core runs `BashExec` normally,
+then subscribed extensions may transform the completed model-visible JSON result
+before it becomes the tool-role message. This keeps native execution, policy,
+approval, tracing, backend selection, and provider correlation in core while
+letting `context_mode` transparently compress large `stdout`/`stderr` payloads.
+
 ## Problem
 
 PR #58 fixes `context_mode` as an explicit extension tool provider: the model can call

--- a/.agent/plans/context_mode/transparent-bash-output-compression.md
+++ b/.agent/plans/context_mode/transparent-bash-output-compression.md
@@ -15,6 +15,68 @@ before it becomes the tool-role message. This keeps native execution, policy,
 approval, tracing, backend selection, and provider correlation in core while
 letting `context_mode` transparently compress large `stdout`/`stderr` payloads.
 
+## AILANG MCP Grounding
+
+The plan is grounded against the AILANG MCP server configured in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "ailang-docs": {
+      "type": "http",
+      "url": "https://mcp.ailang.sunholo.com/mcp/"
+    }
+  }
+}
+```
+
+MCP session facts checked on 2026-06-21:
+
+- `initialize` reported server `ailang-api` version `0.8.1`.
+- `ailang_versions` reported latest docs version `0.25.0`.
+- This repository currently uses local `AILANG v0.24.2`, so implementation must
+  satisfy both MCP-documented syntax and the local compiler.
+
+Language and stdlib grounding:
+
+- `prompt_get(forVersion="0.25.0", kind="agent")` confirms AILANG is a strict
+  Hindley-Milner language with explicit effect rows, slash-based imports, and
+  type-checking through `ailang check`.
+- `effects_catalog(forVersion="0.25.0")` confirms the documented effects used by
+  this plan's hook signatures: `IO`, `FS`, `Net`, `AI`, `Env`, `Clock`,
+  `Process`, and `Stream`.
+- `stdlib_module(name="std/json", forVersion="0.25.0")` confirms `Json`,
+  `encode`, `decode`, `jo`, `kv`, `js`, `jnum`, and related JSON helpers. This
+  grounds the `ToolResultFrame.content: Json` proposal.
+- `stdlib_module(name="std/sem", forVersion="0.25.0")` confirms semantic-frame
+  storage APIs with `SharedMem` and `SharedIndex` effects, including
+  `load_frame`, `store_frame`, `make_frame_at`, and `store_frame_ns`. This
+  grounds the plan's use of SharedMem-backed storage for full tool output.
+- `stdlib_search(query="Trace emit event telemetry", forVersion="0.25.0")`
+  returned no MCP stdlib hits. Treat `Trace` as a Motoko/runtime-local effect
+  seen in this repository, not as an AILANG MCP-documented extension ABI effect.
+  The plan therefore keeps trace emission in host call sites that already carry
+  `Trace`, instead of adding `Trace` to `on_tool_result`.
+
+ABI compatibility grounding:
+
+- MCP searches for `optional record fields default record fields` and
+  `record optional field` returned no feature documentation.
+- MCP record/type-system docs describe row polymorphism/open record types, not
+  optional record fields or defaulted record fields.
+- Local `AILANG v0.24.2` checks reject `field?: type`, reject
+  `field: type = value` inside record types, and reject record literals that
+  omit required fields.
+
+Consequences for this plan:
+
+- Adding `result_tools` and `on_tool_result` to `ExtensionHooks` is a
+  source-breaking ABI change.
+- Every `ExtensionHooks` record literal in in-repo and active registry packages
+  must be updated unless an ABI helper/builder abstraction is introduced first.
+- The proposed hook should use MCP-grounded types and effects only. Runtime-local
+  tracing remains outside the hook signature.
+
 ## Problem
 
 PR #58 fixes `context_mode` as an explicit extension tool provider: the model can call
@@ -141,26 +203,11 @@ Rollout must be versioned:
 4. Regenerate `src/core/ext/registry_generated.ail` and `ailang.lock`.
 5. Run extension boot verification before landing runtime wiring.
 
-If AILANG later supports optional record fields or defaulted hook builders, use
-that to reduce future ABI churn. For this change, assume direct record updates
-are required.
-
-Grounding: `.mcp.json` points to the AILANG MCP server at
-`https://mcp.ailang.sunholo.com/mcp/`. As of MCP server `ailang-api` `0.8.1`,
-`ailang_versions` reports latest docs version `0.25.0`; this repo currently uses
-local `AILANG v0.24.2`. MCP searches for `optional record fields default record
-fields` and `record optional field` returned no feature documentation. The MCP
-record docs describe Hindley-Milner row polymorphism/open record types, not
-optional fields or defaulted record literals. Local compiler checks against
-`v0.24.2` reject:
-
-- `field?: type` in a record type (`expected :, got ?`);
-- `field: type = value` in a record type;
-- constructing a record literal that omits a required field.
-
-So the plan must treat added `ExtensionHooks` fields as a source-breaking ABI
-change unless/until AILANG gains an explicit optional/default field mechanism or
-the ABI package provides a builder/helper abstraction in advance.
+As grounded above against the AILANG MCP docs and the local `v0.24.2` compiler,
+optional/defaulted record fields are not currently available. If AILANG later
+supports optional record fields or the ABI package introduces a defaulted
+hook-builder abstraction, use that to reduce future ABI churn. For this change,
+assume direct record updates are required.
 
 ## Dispatch Semantics
 

--- a/.agent/plans/context_mode/transparent-bash-output-compression.md
+++ b/.agent/plans/context_mode/transparent-bash-output-compression.md
@@ -48,6 +48,28 @@ The core boundary should remain:
   compression.
 - Do not change provider-facing tool call correlation semantics.
 
+## Why Existing Hooks Do Not Fit
+
+This requires a new hook. None of the existing hooks can transparently transform
+native `BashExec` output at the right point in the lifecycle:
+
+- `on_tool_policy` runs before execution and can only allow, deny, defer, or stay
+  neutral. It never sees stdout or stderr.
+- `on_tool_handle` also runs before native execution. If it returns
+  `Handled(result)`, the extension must fully own execution; if it returns
+  `Delegate`, native execution continues but the extension never sees the
+  completed result.
+- `on_response_intercept` sees assistant text responses, not native tool results.
+- `on_solver_candidate` sees final-answer candidates, which is too late to
+  compress tool output before the next model turn.
+- `on_pre_step` can compact or rewrite message history before a later step, but
+  by then the large tool result has already entered the conversation. It also
+  operates on message text rather than structured tool result payloads, making it
+  the wrong layer for preserving tool-call correlation and native result shape.
+
+Therefore the extension boundary needs a post-result decision point: after core
+has executed the native tool and before core emits the tool-role message.
+
 ## Proposed ABI
 
 Add a narrow post-result hook to `ExtensionHooks`. The hook should operate on

--- a/.agent/plans/context_mode/transparent-bash-output-compression.md
+++ b/.agent/plans/context_mode/transparent-bash-output-compression.md
@@ -3,6 +3,9 @@
 Date: 2026-06-21
 Status: planned
 
+Reference: PR #58 discussion comment:
+https://github.com/arniwesth/motoko_agent/pull/58#issuecomment-4761393381
+
 ## TL;DR
 
 Do not give extensions a general native-tool execution callback through
@@ -141,6 +144,23 @@ Rollout must be versioned:
 If AILANG later supports optional record fields or defaulted hook builders, use
 that to reduce future ABI churn. For this change, assume direct record updates
 are required.
+
+Grounding: `.mcp.json` points to the AILANG MCP server at
+`https://mcp.ailang.sunholo.com/mcp/`. As of MCP server `ailang-api` `0.8.1`,
+`ailang_versions` reports latest docs version `0.25.0`; this repo currently uses
+local `AILANG v0.24.2`. MCP searches for `optional record fields default record
+fields` and `record optional field` returned no feature documentation. The MCP
+record docs describe Hindley-Milner row polymorphism/open record types, not
+optional fields or defaulted record literals. Local compiler checks against
+`v0.24.2` reject:
+
+- `field?: type` in a record type (`expected :, got ?`);
+- `field: type = value` in a record type;
+- constructing a record literal that omits a required field.
+
+So the plan must treat added `ExtensionHooks` fields as a source-breaking ABI
+change unless/until AILANG gains an explicit optional/default field mechanism or
+the ABI package provides a builder/helper abstraction in advance.
 
 ## Dispatch Semantics
 

--- a/.agent/prs/mot-12-fix-context-mode.md
+++ b/.agent/prs/mot-12-fix-context-mode.md
@@ -1,0 +1,90 @@
+# Fix context_mode Tool Registration
+
+Base branch: `origin/main`
+
+## Summary
+
+This branch fixes Motoko's `context_mode` extension loading successfully while
+advertising no `Ctx*` tools to the model.
+
+Root cause: the registry package `sunholo/motoko_ext_context_mode@0.2.2`
+contains the real context-mode implementation, but its published
+`register.ail` is a stub. It returns:
+
+- `provided_tools: []`
+- `on_describe_tools: []`
+- no-op policy/handle/finalize hooks
+
+That means the extension can appear in `loaded_extensions`, while the runtime
+tool catalog still has no `CtxDoctor`, `CtxSearch`, `ctx_search`, etc.
+
+## Changes
+
+- Vendor `sunholo/motoko_ext_context_mode` under
+  `packages/motoko-ext-context-mode/` so this branch has a complete,
+  versionable local package override.
+- Point `ailang.toml` at the local package:
+
+  ```toml
+  "sunholo/motoko_ext_context_mode" = { path = "packages/motoko-ext-context-mode" }
+  ```
+
+- Replace the stub registration with a real `register_with_config` that wires:
+  - `provided_tools()` into `ExtensionHooks.provided_tools`
+  - the context-mode prompt patch
+  - Bash policy denial for raw `context-mode` / `ctx_*` probes
+  - direct handling for `Ctx*` / `ctx_*` tool calls
+  - final-output indexing
+- Keep env-backed defaults for context-mode bridge configuration:
+  - `CONTEXT_MODE_BIN`
+  - `CONTEXT_MODE_TIMEOUT_MS`
+  - `CONTEXT_MODE_MAX_OUTPUT_CHARS`
+  - `CONTEXT_MODE_SNAPSHOT_KEY_PREFIX`
+- Add `packages/motoko-ext-context-mode/README.md` explaining that the extension
+  wraps <https://github.com/mksglu/context-mode> and documenting two demo prompts
+  for showing token-saving behavior.
+- Regenerate `ailang.lock` so dependency resolution uses the local context-mode
+  package.
+
+## User Impact
+
+Profiles that include `context_mode` now expose the expected context-mode tools
+to the model, including:
+
+- `CtxDoctor` / `ctx_doctor`
+- `CtxStats` / `ctx_stats`
+- `CtxIndex` / `ctx_index`
+- `CtxSearch` / `ctx_search`
+- `CtxFetchAndIndex` / `ctx_fetch_and_index`
+- `CtxExecute` / `ctx_execute`
+
+This makes context-mode usable for repository archaeology and debugging tasks
+without forcing the agent to read large raw files into the model context.
+
+## Upstream Follow-Up
+
+The upstream `sunholo/motoko_ext_context_mode` package should be updated and
+republished with this fixed `register.ail`. Once a fixed registry version is
+available, Motoko can drop the local path override and return to a normal
+versioned registry dependency.
+
+## Verification
+
+- `MOTOKO_CONFIG=observability make verify_extensions`
+  - `compaction_ai`, `context_mode`, `exa_search`, and `scratchpad` all boot.
+- `make build`
+  - `sync_packages`, extension boot probes, core AILANG checks, and TUI build
+    all pass.
+- `timeout 20s make run PROFILE=observability TASK='Say ready and stop.'`
+  - starts successfully and reports:
+
+    ```text
+    loaded_extensions=compaction_ai, context_mode, exa_search, scratchpad
+    ```
+
+- Direct runtime catalog probe confirms `context_mode` advertises the expected
+  `Ctx*` / `ctx_*` tool names.
+
+Note: the branch used for this PR does not include the autoresearch package.
+Any stale `sunholo/motoko_ext_autoresearch` references were removed from the
+active dependency graph so `make run` works on this branch.

--- a/.agent/summaries/2026-06-21-context-mode-registration-fix.md
+++ b/.agent/summaries/2026-06-21-context-mode-registration-fix.md
@@ -1,0 +1,66 @@
+# Context Mode Registration Fix Session
+
+Date: 2026-06-21
+Branch: `arniwesth/mot-12-fix-context-mode`
+
+## Summary
+
+Investigated why the `context_mode` extension was listed in
+`.motoko/config/observability/config.json` but did not appear in Motoko's
+available tool list. The extension boot probe succeeded, so the issue was not
+profile loading or generated registry resolution. The actual root cause was the
+published `sunholo/motoko_ext_context_mode@0.2.2` package: its `register.ail`
+was a stub returning `provided_tools: []`, `on_describe_tools: []`, and no-op
+hooks, even though the package contained a real `context_mode.ail`
+implementation with `Ctx*` / `ctx_*` tools.
+
+## Changes Made
+
+- Added a versionable local package override at
+  `packages/motoko-ext-context-mode/`.
+- Pointed `ailang.toml` at the local context-mode package instead of the broken
+  registry package.
+- Added a fixed `register.ail` that wires:
+  - `provided_tools()`
+  - context-mode prompt patching
+  - Bash policy denial for raw `context-mode` / `ctx_*` probes
+  - direct `Ctx*` / `ctx_*` tool handling
+  - final-output indexing
+- Regenerated `ailang.lock`.
+- Removed stale `sunholo/motoko_ext_autoresearch` references from the active
+  dependency graph after moving the work to a branch without autoresearch, so
+  `make run` works on this branch.
+- Added `packages/motoko-ext-context-mode/README.md` explaining that
+  `context_mode` wraps <https://github.com/mksglu/context-mode> and documenting
+  two demo prompts:
+  - architecture trace
+  - debugging investigation
+- Wrote PR notes to `.agent/prs/mot-12-fix-context-mode.md`.
+
+## Verification
+
+- `MOTOKO_CONFIG=observability make verify_extensions`
+  - verified `compaction_ai`, `context_mode`, `exa_search`, and `scratchpad`.
+- `make build`
+  - passed package sync, extension boot probes, core AILANG checks, and TUI
+    TypeScript build.
+- `timeout 20s make run PROFILE=observability TASK='Say ready and stop.'`
+  - started successfully and reported:
+    `loaded_extensions=compaction_ai, context_mode, exa_search, scratchpad`.
+- Direct runtime catalog probe confirmed advertised context-mode tools including
+  `CtxDoctor`, `ctx_doctor`, `CtxStats`, `ctx_stats`, `CtxIndex`, `ctx_index`,
+  `CtxSearch`, `ctx_search`, `CtxFetchAndIndex`, and `ctx_fetch_and_index`.
+
+## Follow-Up
+
+The upstream `sunholo/motoko_ext_context_mode` package should be updated and
+republished with the fixed `register.ail`. Once that is available, Motoko can
+drop the local path override and return to a normal registry dependency.
+
+## Notes
+
+- Unrelated untracked directories `ailang/` and `oh-my-pi/` were present and
+  left untouched.
+- A ClickStack `401 Unauthorized` trace-export warning appeared during one
+  direct probe when tracing was configured without auth; it did not affect the
+  context-mode checks.

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,14 @@ src/tui/dist/
 
 # Generated build artifacts
 .packages/
+
+# Local AILANG source checkout used to build a patched binary (e.g. the Bedrock
+# OPENAI_BASE_URL direct-fallback fix). Its own git repo + ailang/.bin/ailang
+# build artifact must never be committed into motoko_agent.
+/ailang/
 # Environment
 .env
+.venv-litellm/
 
 # OS
 .DS_Store

--- a/ailang.lock
+++ b/ailang.lock
@@ -1,6 +1,6 @@
 {
   "ailang_version": "v0.24.2",
-  "generated_at": "2026-06-20T16:26:04.376013772Z",
+  "generated_at": "2026-06-21T06:12:14.472355284Z",
   "generator": "ailang lock v0.24.2",
   "packages": [
     {
@@ -153,7 +153,7 @@
     },
     {
       "ailang": ">=0.17.0",
-      "content_hash": "sha256:58d758f624b58be03570537166aeabeeb2f961dc058e9cc44a5f76858841d729",
+      "content_hash": "sha256:12b246bb7c453aa6973a078c0284118f4dea394e5e52ffff3fb4bfa188923e49",
       "effects": [
         "Clock",
         "Env",
@@ -162,10 +162,18 @@
         "SharedIndex",
         "SharedMem"
       ],
-      "exports": null,
-      "interface_hash": "sha256:3929f261d2c3dc6611761d683c5dcdd08a297ead80d4ad5123ce6a32e951545a",
+      "exports": [
+        "sunholo/motoko_ext_context_mode/compress",
+        "sunholo/motoko_ext_context_mode/context_mode",
+        "sunholo/motoko_ext_context_mode/exec",
+        "sunholo/motoko_ext_context_mode/prompts",
+        "sunholo/motoko_ext_context_mode/register",
+        "sunholo/motoko_ext_context_mode/types"
+      ],
+      "interface_hash": "sha256:a449adb0a65552c085b8a48f136e78a29a3d2390902b2a51acc1815f372632e1",
       "name": "sunholo/motoko_ext_context_mode",
-      "source": "registry",
+      "path": "/workspaces/motoko_agent/packages/motoko-ext-context-mode",
+      "source": "path",
       "version": "0.2.2"
     },
     {

--- a/ailang.toml
+++ b/ailang.toml
@@ -7,13 +7,11 @@ ailang = ">=0.24.2"
 
 [dependencies]
 "sunholo/logging" = "0.4.0"
-# Registry-published versions (ailang-packages 2026-05-08). Local-path overrides
-# removed so external clones / Arni's PR review work without needing
-# ../ailang-packages alongside the checkout.
+# Registry-published versions (ailang-packages 2026-05-08).
 "sunholo/motoko_ext_abi" = "2.2.0"
 "sunholo/motoko_ext_test_dummy" = "0.2.2"
 "sunholo/motoko_ext_omnigraph" = "0.2.3"
-"sunholo/motoko_ext_context_mode" = "0.2.2"
+"sunholo/motoko_ext_context_mode" = { path = "packages/motoko-ext-context-mode" }
 "sunholo/motoko_ext_mcp" = "0.2.7"
 "sunholo/motoko_ext_exa_search" = "0.2.7"
 "sunholo/motoko_ext_ai_compat" = "0.2.1"

--- a/packages/motoko-ext-context-mode/AGENT.md
+++ b/packages/motoko-ext-context-mode/AGENT.md
@@ -1,0 +1,20 @@
+# motoko_context_mode
+
+Context-mode extension routing card for Motoko.
+
+Routing rules:
+- Extension-provided tools are authoritative. Use them directly even if the generic "Available Tools" table omits them.
+- Never use `BashExec` for `context-mode` or `ctx_*` probing. Do not run `which`, `--help`, or other preflight checks for these tools.
+- For context-mode testing, call tools directly in this order:
+  1. `CtxDoctor` (`ctx_doctor`) for health.
+  2. `CtxStats` (`ctx_stats`) for session/index state.
+  3. Requested operation (`CtxSearch`, `CtxIndex`, `CtxFetchAndIndex`, `CtxExecute`, etc.).
+- Prefer `ctx_execute` for exploratory code execution and shell-like inspection.
+- Use `ctx_search` to recover prior session facts from context-mode's index.
+- Use `ctx_index` for durable findings that should survive compaction.
+- Prefer `ctx_fetch_and_index` over raw `curl`/`wget` fetches.
+
+Notes:
+- This extension calls the context-mode MCP bridge script in `scripts/context-mode-mcp-call.mjs`.
+- The extension performs a readiness preflight (`CtxDoctor`) once per session before non-doctor `Ctx*` calls, which auto-starts/verifies context-mode as needed.
+- If the bridge or binary is unavailable, calls may delegate to core handling.

--- a/packages/motoko-ext-context-mode/README.md
+++ b/packages/motoko-ext-context-mode/README.md
@@ -1,0 +1,54 @@
+# Motoko context_mode Extension
+
+`context_mode` is Motoko's wrapper around
+[mksglu/context-mode](https://github.com/mksglu/context-mode). It exposes
+context-mode operations as Motoko extension tools so an agent can index, search,
+and reuse repository context without repeatedly reading large raw files into the
+conversation.
+
+The extension is intended for codebase archaeology and debugging tasks where the
+agent needs to correlate several files but should keep the model context small.
+It advertises tools such as `CtxDoctor`, `CtxStats`, `CtxIndex`, `CtxSearch`,
+`CtxFetchAndIndex`, and their `ctx_*` aliases.
+
+## Demo Prompts
+
+Use these prompts to exercise token-saving behavior on non-trivial repo
+questions.
+
+### Architecture Trace
+
+```text
+Use context_mode to investigate the extension system in this repository and produce a concise architecture note.
+
+Do not answer from memory. Use the Ctx* tools directly, not BashExec, for the context-mode part.
+
+Task:
+1. Index the relevant source files for Motoko's extension loading and tool advertisement path.
+2. Find how an extension listed in `.motoko/config/observability/config.json` becomes available to the model as a tool.
+3. Trace the path for `context_mode` specifically, from profile config to registry resolution to advertised tool schemas.
+4. Identify the minimum set of files that matter and explain each file's role.
+5. Report how many tool calls you used, and for each context-mode call, summarize why it avoided reading larger raw files.
+
+Constraints:
+- Keep the final answer under 500 words.
+- Include exact file paths.
+- Include at least one concrete example of a tool name that should appear because of context_mode.
+- Do not dump full file contents.
+```
+
+### Debugging Investigation
+
+```text
+Use context_mode to answer this repository archaeology question with minimal context usage:
+
+"Why would `context_mode` appear in `loaded_extensions` but not show any `Ctx*` tools to the model?"
+
+Use CtxIndex/CtxSearch/CtxStats/CtxDoctor or their snake_case aliases as appropriate. Avoid reading entire files unless context_mode cannot answer. Your final answer must include:
+- the suspected failure mode,
+- the exact registration fields involved,
+- the files that prove it,
+- and a compact fix strategy.
+
+Keep the final answer under 400 words and do not paste large snippets.
+```

--- a/packages/motoko-ext-context-mode/ailang.toml
+++ b/packages/motoko-ext-context-mode/ailang.toml
@@ -1,0 +1,21 @@
+[package]
+name = "sunholo/motoko_ext_context_mode"
+version = "0.2.2"
+edition = "1"
+ailang = ">=0.17.0"
+
+[exports]
+modules = [
+  "sunholo/motoko_ext_context_mode/compress",
+  "sunholo/motoko_ext_context_mode/context_mode",
+  "sunholo/motoko_ext_context_mode/exec",
+  "sunholo/motoko_ext_context_mode/prompts",
+  "sunholo/motoko_ext_context_mode/register",
+  "sunholo/motoko_ext_context_mode/types",
+]
+
+[dependencies]
+"sunholo/motoko_ext_abi" = "2.2.0"
+
+[effects]
+max = ["Process", "FS", "Env", "SharedMem", "Clock", "SharedIndex"]

--- a/packages/motoko-ext-context-mode/compress.ail
+++ b/packages/motoko-ext-context-mode/compress.ail
@@ -1,0 +1,74 @@
+module sunholo/motoko_ext_context_mode/compress
+
+import std/string (trim, split, join, replace, contains)
+
+func normalize_newlines(text: string) -> string {
+  replace(replace(text, "\r\n", "\n"), "\r", "\n")
+}
+
+func strip_ansi_escape_char(text: string) -> string {
+  replace(text, "\u001b", "")
+}
+
+func collapse_spaces_once(text: string) -> string {
+  replace(text, "  ", " ")
+}
+
+func collapse_spaces(text: string) -> string {
+  let next = collapse_spaces_once(text);
+  if next == text then text else collapse_spaces(next)
+}
+
+func trim_non_empty_lines(lines: [string]) -> [string] {
+  match lines {
+    [] => [],
+    x :: rest => {
+      let t = trim(x);
+      if t == "" then trim_non_empty_lines(rest)
+      else t :: trim_non_empty_lines(rest)
+    }
+  }
+}
+
+func count_same_prefix(lines: [string], value: string, n: int) -> { count: int, rest: [string] } {
+  match lines {
+    [] => { count: n, rest: [] },
+    x :: rest =>
+      if x == value then count_same_prefix(rest, value, n + 1)
+      else { count: n, rest: lines }
+  }
+}
+
+func collapse_repeated_lines(lines: [string]) -> [string] {
+  match lines {
+    [] => [],
+    x :: rest => {
+      let grouped = count_same_prefix(rest, x, 1);
+      if grouped.count >= 4 then {
+        [x, "(repeated ${show(grouped.count)}x)"] ++ collapse_repeated_lines(grouped.rest)
+      } else {
+        [x] ++ collapse_repeated_lines(rest)
+      }
+    }
+  }
+}
+
+func truncate_with_suffix(text: string, max_chars: int) -> string
+  requires { max_chars >= 0 }
+  {
+    if max_chars <= 0 then ""
+    else if _str_len(text) <= max_chars then text
+    else if max_chars <= 24 then _str_slice(text, 0, max_chars)
+    else {
+      let kept = _str_slice(text, 0, max_chars - 24);
+      "${kept}\n... (truncated)"
+    }
+  }
+
+export func compress_output(text: string, max_chars: int) -> string
+  requires { max_chars >= 0 }
+  {
+    let clean = collapse_spaces(strip_ansi_escape_char(normalize_newlines(text)));
+    let compact = join("\n", collapse_repeated_lines(trim_non_empty_lines(split(clean, "\n"))));
+    truncate_with_suffix(compact, max_chars)
+  }

--- a/packages/motoko-ext-context-mode/context_mode.ail
+++ b/packages/motoko-ext-context-mode/context_mode.ail
@@ -1,0 +1,187 @@
+module sunholo/motoko_ext_context_mode/context_mode
+
+import std/bytes (fromString, toString)
+import std/json (Json, encode, jo, kv, js, get, asString)
+import std/option (Option, Some, None)
+import std/sem (make_frame_at, store_frame, load_frame)
+import std/string (toLower, trim, contains, startsWith)
+
+import pkg/sunholo/motoko_ext_abi/types (ToolCallEnvelope, ExtCtx, PromptPatch, BudgetPlan, BudgetPatch, ToolPolicyDecision, ToolHandleDecision, ResponseInterceptDecision, FinalizeDecision)
+import pkg/sunholo/motoko_ext_context_mode/types (CtxConfig)
+import pkg/sunholo/motoko_ext_context_mode/exec (run_context_mode, run_context_mode_fire_and_forget)
+import pkg/sunholo/motoko_ext_context_mode/prompts (build_prompt_patch)
+
+func snapshot_key_for(prefix: string, state_key: string) -> string {
+  "${prefix}${state_key}"
+}
+
+func read_snapshot(prefix: string, state_key: string) -> string ! {SharedMem} {
+  match load_frame(snapshot_key_for(prefix, state_key)) {
+    Some(frame) => toString(frame.opaque),
+    None => ""
+  }
+}
+
+func write_snapshot(prefix: string, state_key: string, snapshot: string) -> () ! {SharedMem} {
+  let key = snapshot_key_for(prefix, state_key);
+  let frame = make_frame_at(key, "context-mode session snapshot", fromString(snapshot), 0);
+  store_frame(key, frame)
+}
+
+func ready_key_for(prefix: string, state_key: string) -> string {
+  "${prefix}ready:${state_key}"
+}
+
+func is_ready(prefix: string, state_key: string) -> bool ! {SharedMem} {
+  match load_frame(ready_key_for(prefix, state_key)) {
+    Some(_) => true,
+    None => false
+  }
+}
+
+func mark_ready(prefix: string, state_key: string) -> () ! {SharedMem} {
+  let key = ready_key_for(prefix, state_key);
+  let frame = make_frame_at(key, "context-mode readiness marker", fromString("1"), 0);
+  store_frame(key, frame)
+}
+
+func arg_string(args: Json, key: string, fallback: string) -> string {
+  match get(args, key) {
+    Some(j) => match asString(j) {
+      Some(v) => v,
+      None => fallback
+    },
+    None => fallback
+  }
+}
+
+func denied_bash_reason(call: ToolCallEnvelope) -> Option[string] {
+  if call.tool != "BashExec" then None
+  else {
+    let cmd = toLower(trim(arg_string(call.arguments, "cmd", "")));
+    let has_url = contains(cmd, "http://") || contains(cmd, "https://");
+    if cmd == "" then None
+    else if has_url then
+      Some("Do not fetch remote URLs via BashExec when context_mode is loaded. Use CtxFetchAndIndex/ctx_fetch_and_index for URL retrieval, then CtxSearch/ctx_search for follow-up queries.")
+    else if contains(cmd, "context-mode")
+      || contains(cmd, "ctx_stats")
+      || contains(cmd, "ctx_doctor")
+      || contains(cmd, "ctx_search")
+      || contains(cmd, "ctxstats")
+      || contains(cmd, "ctxdoctor")
+      || contains(cmd, "ctxsearch")
+      || startsWith(cmd, "ctx_")
+      || startsWith(cmd, "ctx.")
+      then Some("Do not run context-mode or Ctx* probes via BashExec. Call extension tools directly via JSON tool_calls (CtxStats/CtxDoctor/CtxSearch or ctx_stats/ctx_doctor/ctx_search), even if they are not listed in the generic tool table.")
+    else None
+  }
+}
+
+export func on_tool_policy(_ctx: ExtCtx, call: ToolCallEnvelope) -> ToolPolicyDecision {
+  match denied_bash_reason(call) {
+    Some(msg) => Deny(msg),
+    None => NoOpinion
+  }
+}
+
+export func canonical_tool_name(raw: string) -> string {
+  let t = toLower(trim(raw));
+  if t == "ctxexecute" || t == "ctx_execute" || t == "ctx.execute" || t == "context_mode.execute" then "CtxExecute"
+  else if t == "ctxbatchexecute" || t == "ctx_batch_execute" || t == "ctx.batch_execute" || t == "context_mode.batch_execute" then "CtxBatchExecute"
+  else if t == "ctxexecutefile" || t == "ctx_execute_file" || t == "ctx.execute_file" || t == "context_mode.execute_file" then "CtxExecuteFile"
+  else if t == "ctxindex" || t == "ctx_index" || t == "ctx.index" || t == "context_mode.index" then "CtxIndex"
+  else if t == "ctxsearch" || t == "ctx_search" || t == "ctx.search" || t == "context_mode.search" then "CtxSearch"
+  else if t == "ctxfetchandindex" || t == "ctx_fetch_and_index" || t == "ctx.fetch_and_index" || t == "context_mode.fetch_and_index" then "CtxFetchAndIndex"
+  else if t == "ctxstats" || t == "ctx_stats" || t == "ctx.stats" || t == "context_mode.stats" then "CtxStats"
+  else if t == "ctxdoctor" || t == "ctx_doctor" || t == "ctx.doctor" || t == "context_mode.doctor" then "CtxDoctor"
+  else if t == "ctxpurge" || t == "ctx_purge" || t == "ctx.purge" || t == "context_mode.purge" then "CtxPurge"
+  else ""
+}
+
+func action_name(canonical: string) -> string {
+  if canonical == "CtxExecute" then "ctx_execute"
+  else if canonical == "CtxBatchExecute" then "ctx_batch_execute"
+  else if canonical == "CtxExecuteFile" then "ctx_execute_file"
+  else if canonical == "CtxIndex" then "ctx_index"
+  else if canonical == "CtxSearch" then "ctx_search"
+  else if canonical == "CtxFetchAndIndex" then "ctx_fetch_and_index"
+  else if canonical == "CtxStats" then "ctx_stats"
+  else if canonical == "CtxDoctor" then "ctx_doctor"
+  else if canonical == "CtxPurge" then "ctx_purge"
+  else ""
+}
+
+func bridge_args_for(cfg: CtxConfig, ctx: ExtCtx, tool_name: string, args: Json) -> [string] {
+  [
+    "${ctx.workdir}/scripts/context-mode-mcp-call.mjs",
+    "--context-mode-bin", cfg.bin,
+    "--tool", tool_name,
+    "--args-json", encode(args),
+    "--timeout-ms", show(cfg.timeout_ms)
+  ]
+}
+
+func ensure_context_mode_ready(cfg: CtxConfig, ctx: ExtCtx, tool_name: string) -> bool ! {Process, SharedMem} {
+  if tool_name == "ctx_doctor" then true
+  else if is_ready(cfg.snapshot_key_prefix, ctx.state_key) then true
+  else {
+    let ok = run_context_mode_fire_and_forget("node", bridge_args_for(cfg, ctx, "ctx_doctor", jo([])), ctx.cwd, cfg.timeout_ms);
+    if ok then {
+      mark_ready(cfg.snapshot_key_prefix, ctx.state_key);
+      true
+    } else false
+  }
+}
+
+-- Tool names advertised to the model. MUST match Anthropic's Bedrock
+-- pattern ^[a-zA-Z0-9_-]{1,128}$ — no dots, no slashes, no colons.
+-- The 18 dotted aliases (ctx.execute / context_mode.execute / etc) were
+-- dropped in motoko v0.18.1 because Bedrock rejects them at the
+-- tools[].custom.name validator (other Anthropic backends are permissive
+-- but Bedrock is strict). canonical_tool_name() still maps the dotted
+-- forms as INPUT — in case a model generated them despite not seeing
+-- them advertised — so the normalizer is unchanged. Only the OUTPUT
+-- (advertised) list needs Bedrock-compat names.
+export func provided_tools() -> [string] {
+  [
+    "CtxExecute", "ctx_execute",
+    "CtxBatchExecute", "ctx_batch_execute",
+    "CtxExecuteFile", "ctx_execute_file",
+    "CtxIndex", "ctx_index",
+    "CtxSearch", "ctx_search",
+    "CtxFetchAndIndex", "ctx_fetch_and_index",
+    "CtxStats", "ctx_stats",
+    "CtxDoctor", "ctx_doctor",
+    "CtxPurge", "ctx_purge"
+  ]
+}
+
+export func on_build_system_prompt(cached_prompt: string, _ctx: ExtCtx) -> PromptPatch {
+  build_prompt_patch(cached_prompt, "")
+}
+
+export func on_tool_handle(cfg: CtxConfig, ctx: ExtCtx, call: ToolCallEnvelope) -> ToolHandleDecision ! {Process, SharedMem} {
+  let canonical = canonical_tool_name(call.tool);
+  if canonical == "" then Delegate
+  else {
+    let tool_name = action_name(canonical);
+    if tool_name == "" then Delegate
+    else {
+      let _ = ensure_context_mode_ready(cfg, ctx, tool_name);
+      match run_context_mode(call.id, canonical, "node", bridge_args_for(cfg, ctx, tool_name, call.arguments), ctx.cwd, cfg.timeout_ms, cfg.max_output_chars) {
+      Some(result) => Handled(result),
+      None => Delegate
+      }
+    }
+  }
+}
+
+export func finalize_with_index(cfg: CtxConfig, ctx: ExtCtx, candidate: string) -> FinalizeDecision ! {Process} {
+  let idx_args = jo([
+    kv("content", js(candidate)),
+    kv("source", js("motoko:final_output")),
+    kv("metadata", jo([kv("task", js(ctx.task)), kv("model", js(ctx.model))]))
+  ]);
+  let _ = run_context_mode_fire_and_forget("node", bridge_args_for(cfg, ctx, "ctx_index", idx_args), ctx.cwd, cfg.timeout_ms);
+  NoDecision
+}

--- a/packages/motoko-ext-context-mode/exec.ail
+++ b/packages/motoko-ext-context-mode/exec.ail
@@ -1,0 +1,113 @@
+module sunholo/motoko_ext_context_mode/exec
+
+import std/bytes (toString)
+import std/json (Json, decode, encode, jo, kv, js)
+import std/option (Option, Some, None)
+import std/process (exec, ProcessError)
+import std/string (trim, toLower, contains)
+import pkg/sunholo/motoko_ext_abi/types (ToolResultEnvelope)
+import pkg/sunholo/motoko_ext_context_mode/compress (compress_output)
+
+func process_error_to_string(err: ProcessError) -> string {
+  match err {
+    NotAllowed(cmd) => "not allowed: ${cmd}",
+    NotFound(cmd) => "not found: ${cmd}",
+    PermissionDenied(cmd) => "permission denied: ${cmd}",
+    Timeout(ms) => "timeout after ${show(ms)}ms",
+    OutputLimitExceeded(n) => "output limit exceeded: ${show(n)} bytes",
+    SpawnFailed(msg) => "spawn failed: ${msg}",
+    AbnormalExit(sig, name) => "abnormal exit signal ${show(sig)} (${name})"
+  }
+}
+
+func is_binary_missing(err: ProcessError) -> bool {
+  match err {
+    NotFound(_) => true,
+    SpawnFailed(_) => true,
+    _ => false
+  }
+}
+
+export func parse_output_json(raw_stdout: string) -> Json {
+  let t = trim(raw_stdout);
+  if t == "" then jo([kv("output", js(""))])
+  else
+    match decode(t) {
+      Ok(parsed) => parsed,
+      Err(_) => jo([kv("output", js(t))])
+    }
+}
+
+func timeout_seconds(timeout_ms: int) -> int {
+  if timeout_ms <= 0 then 0
+  else {
+    let secs = timeout_ms / 1000;
+    if (secs * 1000) < timeout_ms then secs + 1 else secs
+  }
+}
+
+export func build_shell_argv(bin: string, args: [string], cwd: string, timeout_ms: int) -> [string] {
+  let secs = timeout_seconds(timeout_ms);
+  let script = if secs > 0 then
+    "set -eu\ncd \"$1\"\nPATH=\"$HOME/.local/bin:$PATH\"\nbin=\"$2\"\nduration=\"$3\"\nshift 3\ntimeout \"$duration\" \"$bin\" \"$@\""
+    else
+    "set -eu\ncd \"$1\"\nPATH=\"$HOME/.local/bin:$PATH\"\nbin=\"$2\"\nshift 2\n\"$bin\" \"$@\"";
+  if secs > 0 then ["-lc", script, "motoko-context-mode", cwd, bin, "${show(secs)}s"] ++ args
+  else ["-lc", script, "motoko-context-mode", cwd, bin] ++ args
+}
+
+func shell_exec(bin: string, args: [string], cwd: string, timeout_ms: int) -> Option[{ stdout: string, stderr: string, exit_code: int, err: string }] ! {Process} {
+  let argv = build_shell_argv(bin, args, cwd, timeout_ms);
+  match exec("bash", argv) {
+    Err(e) => {
+      if is_binary_missing(e) then None
+      else Some({ stdout: "", stderr: "", exit_code: 1, err: process_error_to_string(e) })
+    },
+    Ok(out) => Some({ stdout: toString(out.stdout), stderr: toString(out.stderr), exit_code: out.exitCode, err: "" })
+  }
+}
+
+func error_envelope(id: string, tool: string, message: string) -> ToolResultEnvelope {
+  {
+    tool_call_id: id,
+    tool: tool,
+    stdout: "",
+    stderr: message,
+    exit_code: 1,
+    metadata: jo([kv("json_metadata", js(encode(jo([kv("output", js(message))]))))])
+  }
+}
+
+func looks_like_missing_binary(stderr: string, exit_code: int) -> bool {
+  let s = toLower(stderr);
+  exit_code == 127 && (contains(s, "context-mode") && contains(s, "not found") || contains(s, "command not found"))
+}
+
+export func run_context_mode(id: string, tool: string, bin: string, args: [string], cwd: string, timeout_ms: int, max_chars: int) -> Option[ToolResultEnvelope] ! {Process} {
+  match shell_exec(bin, args, cwd, timeout_ms) {
+    None => None,
+    Some(out) => {
+      if out.err != "" then Some(error_envelope(id, tool, out.err))
+      else if looks_like_missing_binary(out.stderr, out.exit_code) then None
+      else {
+        let stdout = compress_output(out.stdout, max_chars);
+        let stderr = compress_output(out.stderr, max_chars);
+        Some({
+          tool_call_id: id,
+          tool: tool,
+          stdout: stdout,
+          stderr: stderr,
+          exit_code: out.exit_code,
+          metadata: jo([kv("json_metadata", js(encode(parse_output_json(stdout))))])
+        })
+      }
+    }
+  }
+}
+
+export func run_context_mode_fire_and_forget(bin: string, args: [string], cwd: string, timeout_ms: int) -> bool ! {Process} {
+  match shell_exec(bin, args, cwd, timeout_ms) {
+    None => false,
+    Some(_) => true
+  }
+}

--- a/packages/motoko-ext-context-mode/prompts.ail
+++ b/packages/motoko-ext-context-mode/prompts.ail
@@ -1,0 +1,18 @@
+module sunholo/motoko_ext_context_mode/prompts
+
+import std/fs (fileExists, readFile)
+import pkg/sunholo/motoko_ext_abi/types (PromptPatch)
+
+export func load_agent_prompt(cwd: string) -> string ! {FS} {
+  let workspace_path = "${cwd}/src/core/ext/context_mode/AGENT.md";
+  let packaged_workspace_path = "${cwd}/.packages/motoko_context_mode/AGENT.md";
+  if fileExists(workspace_path) then readFile(workspace_path)
+  else if fileExists(packaged_workspace_path) then readFile(packaged_workspace_path)
+  else ""
+}
+
+export func build_prompt_patch(cached_prompt: string, snapshot: string) -> PromptPatch {
+  if cached_prompt == "" && snapshot == "" then { prepend: [], append: [] }
+  else if snapshot == "" then { prepend: [], append: [cached_prompt] }
+  else { prepend: [], append: [cached_prompt, "Session snapshot:\n${snapshot}"] }
+}

--- a/packages/motoko-ext-context-mode/register.ail
+++ b/packages/motoko-ext-context-mode/register.ail
@@ -1,0 +1,77 @@
+module sunholo/motoko_ext_context_mode/register
+
+import std/env (getEnvOr)
+import std/option (None)
+import std/string (stringToInt)
+
+import pkg/sunholo/motoko_ext_abi/types (
+  ExtensionHooks,
+  ExtCtx,
+  BudgetPlan,
+  BudgetPatch,
+  ToolHandleDecision,
+  FinalizeDecision,
+  PreStepDecision,
+  PassThrough,
+  Msg
+)
+import pkg/sunholo/motoko_ext_context_mode/types (CtxConfig)
+import pkg/sunholo/motoko_ext_context_mode/context_mode (
+  provided_tools,
+  on_build_system_prompt,
+  on_tool_policy,
+  on_tool_handle,
+  finalize_with_index
+)
+import pkg/sunholo/motoko_ext_context_mode/prompts (load_agent_prompt)
+
+func parse_int_or(s: string, fallback: int) -> int {
+  match stringToInt(s) {
+    Some(n) => n,
+    None => fallback
+  }
+}
+
+func no_budget_patch() -> BudgetPatch {
+  {
+    requested_total: None,
+    requested_solver: None,
+    requested_verifier: None
+  }
+}
+
+func budget_hook(_ctx: ExtCtx, _plan: BudgetPlan) -> BudgetPatch ! {Env, FS} {
+  no_budget_patch()
+}
+
+func config_from_env() -> CtxConfig ! {Env} {
+  {
+    bin: getEnvOr("CONTEXT_MODE_BIN", "context-mode"),
+    timeout_ms: parse_int_or(getEnvOr("CONTEXT_MODE_TIMEOUT_MS", "25000"), 25000),
+    max_output_chars: parse_int_or(getEnvOr("CONTEXT_MODE_MAX_OUTPUT_CHARS", "6000"), 6000),
+    snapshot_key_prefix: getEnvOr("CONTEXT_MODE_SNAPSHOT_KEY_PREFIX", "ctxmode:snapshot:")
+  }
+}
+
+export func register_with_config(_cfg: a) -> ExtensionHooks ! {Env, FS} {
+  let cfg = config_from_env();
+  let cached_prompt = load_agent_prompt(getEnvOr("MOTOKO_WORKDIR", "."));
+  let handle = func(ctx: ExtCtx, call) -> ToolHandleDecision ! {IO, Process, FS, AI, Env, Net, SharedMem, Clock, Stream} {
+    on_tool_handle(cfg, ctx, call)
+  };
+  let finalize = func(ctx: ExtCtx, candidate: string) -> FinalizeDecision ! {IO, Process, FS, AI, Env, Net, SharedMem, Clock, Stream} {
+    finalize_with_index(cfg, ctx, candidate)
+  };
+  {
+    id: "context_mode",
+    provided_tools: provided_tools(),
+    on_describe_tools: \_ . [],
+    on_build_system_prompt: \ctx. on_build_system_prompt(cached_prompt, ctx),
+    on_budget_plan: budget_hook,
+    on_pre_step: func(_ctx: ExtCtx, _msgs: [Msg]) -> PreStepDecision ! {IO, Process, FS, AI, Env, Net, SharedMem, Clock, Stream} { PassThrough },
+    on_tool_policy: on_tool_policy,
+    on_tool_handle: handle,
+    on_response_intercept: \_ _ . NoIntercept ! {IO, Process, FS, AI, Env, Net, SharedMem, Clock, Stream},
+    on_solver_candidate: finalize
+  }
+}

--- a/packages/motoko-ext-context-mode/types.ail
+++ b/packages/motoko-ext-context-mode/types.ail
@@ -1,0 +1,13 @@
+module sunholo/motoko_ext_context_mode/types
+
+export type CtxConfig = {
+  bin: string,
+  timeout_ms: int,
+  max_output_chars: int,
+  snapshot_key_prefix: string
+}
+
+export type CtxSession = {
+  snapshot: string,
+  loaded: bool
+}


### PR DESCRIPTION
# Fix context_mode Tool Registration

Base branch: `origin/main`

## Summary

This branch fixes Motoko's `context_mode` extension loading successfully while
advertising no `Ctx*` tools to the model.

Root cause: the registry package `sunholo/motoko_ext_context_mode@0.2.2`
contains the real context-mode implementation, but its published
`register.ail` is a stub. It returns:

- `provided_tools: []`
- `on_describe_tools: []`
- no-op policy/handle/finalize hooks

That means the extension can appear in `loaded_extensions`, while the runtime
tool catalog still has no `CtxDoctor`, `CtxSearch`, `ctx_search`, etc.

## Changes

- Vendor `sunholo/motoko_ext_context_mode` under
  `packages/motoko-ext-context-mode/` so this branch has a complete,
  versionable local package override.
- Point `ailang.toml` at the local package:

  ```toml
  "sunholo/motoko_ext_context_mode" = { path = "packages/motoko-ext-context-mode" }
  ```

- Replace the stub registration with a real `register_with_config` that wires:
  - `provided_tools()` into `ExtensionHooks.provided_tools`
  - the context-mode prompt patch
  - Bash policy denial for raw `context-mode` / `ctx_*` probes
  - direct handling for `Ctx*` / `ctx_*` tool calls
  - final-output indexing
- Keep env-backed defaults for context-mode bridge configuration:
  - `CONTEXT_MODE_BIN`
  - `CONTEXT_MODE_TIMEOUT_MS`
  - `CONTEXT_MODE_MAX_OUTPUT_CHARS`
  - `CONTEXT_MODE_SNAPSHOT_KEY_PREFIX`
- Add `packages/motoko-ext-context-mode/README.md` explaining that the extension
  wraps <https://github.com/mksglu/context-mode> and documenting two demo prompts
  for showing token-saving behavior.
- Regenerate `ailang.lock` so dependency resolution uses the local context-mode
  package.

## User Impact

Profiles that include `context_mode` now expose the expected context-mode tools
to the model, including:

- `CtxDoctor` / `ctx_doctor`
- `CtxStats` / `ctx_stats`
- `CtxIndex` / `ctx_index`
- `CtxSearch` / `ctx_search`
- `CtxFetchAndIndex` / `ctx_fetch_and_index`
- `CtxExecute` / `ctx_execute`

This makes context-mode usable for repository archaeology and debugging tasks
without forcing the agent to read large raw files into the model context.

## Upstream Follow-Up

The upstream `sunholo/motoko_ext_context_mode` package should be updated and
republished with this fixed `register.ail`. Once a fixed registry version is
available, Motoko can drop the local path override and return to a normal
versioned registry dependency.

## Verification

- `MOTOKO_CONFIG=observability make verify_extensions`
  - `compaction_ai`, `context_mode`, `exa_search`, and `scratchpad` all boot.
- `make build`
  - `sync_packages`, extension boot probes, core AILANG checks, and TUI build
    all pass.
- `timeout 20s make run PROFILE=observability TASK='Say ready and stop.'`
  - starts successfully and reports:

    ```text
    loaded_extensions=compaction_ai, context_mode, exa_search, scratchpad
    ```

- Direct runtime catalog probe confirms `context_mode` advertises the expected
  `Ctx*` / `ctx_*` tool names.

Note: the branch used for this PR does not include the autoresearch package.
Any stale `sunholo/motoko_ext_autoresearch` references were removed from the
active dependency graph so `make run` works on this branch.
