### PR TITLE
Arniwesth/mot 15 fix ascii graph rendering spilling into context window

### DIFF
--- a/.agent/plans/omp-style-python-eval/07-scratchpad-result-context-bloat-fix.md
+++ b/.agent/plans/omp-style-python-eval/07-scratchpad-result-context-bloat-fix.md
@@ -1,0 +1,183 @@
+# Plan: stop scratchpad cell `metadata` from blowing the model context window
+
+Feature context: the scratchpad/eval tool (plans [01](./01-design-c-mvp-local-loopback.md), [03](./03-eval-tui-card-rendering.md)) and inline image rendering ([plan 04](./04-eval-inline-image-rendering.md)).
+Status: **bug fix.** Discovered 2026-06-21 running `PROFILE=bedrock` (model `gpt-bedrock-opus-4-8`) with the `scratchpad` extension active and image/graph output.
+
+## Symptom
+
+A scratchpad run that rendered graphs failed mid-stream:
+
+```
+litellm.ContextWindowExceededError: BedrockException: Context Window Error -
+  prompt is too long: 1460049 tokens > 1000000 maximum
+model=gpt-bedrock-opus-4-8
+```
+
+1.46M tokens (~5–6 MB of text) in a single prompt. The scratchpad's rendered
+image/ANSI output is ending up **in the model conversation**, not just on screen.
+
+## Root cause
+
+The scratchpad has two output sinks and the model sink wrongly receives the
+full, uncapped cell payload.
+
+Verified hop-by-hop (current code, scratchpad naming; this is the same data path
+plan 04's hop table describes under the older "eval" names):
+
+| Hop | File:line | Carries full cells (base64 + ANSI)? |
+|---|---|---|
+| env-server builds response | `src/tui/src/env-server.ts:949-957` — `{ stdout: buildScratchpadTranscript(...) (50 KB cap), cells (UNCAPPED), images, jsonOutputs }`. `spillImages` writes images to disk but does **not** strip `displays[].data` base64 from `cells`. | ✅ |
+| brain decodes response | `src/core/env_client.ail:144` — `exec_scratchpad_cell` returns `metadata: obj`, i.e. the **entire** decoded response (incl. uncapped `cells`). | ✅ |
+| brain → TUI event (intended) | `src/core/agent_loop_v2.ail:188-201` — `emit_scratchpad_result_if_present` emits `scratchpad_result` with `cells_json = encode(metadata.cells)`. **This is correct** — plan 04 relies on base64 reaching the TUI for inline Kitty/iTerm2 image rendering. | ✅ (by design) |
+| brain → **model message** (the bug) | `src/core/agent_loop_v2.ail:776` (scratchpad-handled branch) and `:799` (generic `Handled` branch) — `content: encode(result_to_json(result_env))`. | ✅ **leak** |
+| serializer includes metadata | `src/core/tool_contract.ail:31-40` — `result_to_json` emits `metadata` verbatim (line 38), alongside the already-capped `stdout`. | ✅ |
+
+So the tool-role `Message.content` the model sees contains the **full
+`metadata.cells`** — every cell's base64 image `data` plus rendered ANSI/text
+bundles — re-sent on every subsequent turn. The 50 KB `buildScratchpadTranscript`
+cap only governs `stdout`; `metadata.cells` bypasses it entirely.
+
+### Why the existing safeguards don't catch it
+- `buildScratchpadTranscript` (`transcript.ts`, `DEFAULT_LIMIT = 50*1024`) caps
+  only `stdout`, and correctly renders images as `[image: <path> (WxH mime)]`
+  references — but that capped string is *not* the only thing sent to the model.
+- `compaction_ai` can shrink history over time, but this is a single-turn
+  blow-up that exceeds the window before compaction can run.
+
+### The load-bearing constraint
+The base64 in `cells`/`cells_json` is **intentional** for the TUI (plan 04
+inline images). The fix must therefore **separate the brain→TUI path (keep full
+cells) from the brain→model path (slim)** — it must not strip base64 at the
+env-server or in `metadata`, or it regresses inline image rendering.
+
+## Goals
+
+- A scratchpad tool result sent to the model is **bounded** regardless of how
+  many images/how much ANSI a cell produces — no single tool message can blow
+  the context window.
+- The model still receives a useful observation: the capped transcript
+  (`stdout`) with `[image: <path> …]` references, stdout/stderr, results, errors,
+  and exit code.
+- The TUI `scratchpad_result` event is **unchanged** — full `cells` (incl.
+  base64) keep flowing for inline image rendering (plan 04).
+- Systemic, not scratchpad-only: any extension returning large `metadata` is
+  prevented from bloating the model context (per AILANG "audit before patching").
+
+## Non-goals
+
+- No change to the env-server cell payload, the wire/frame protocol, or
+  `cells_json` (TUI keeps base64). No kernel changes.
+- No change to inline image rendering (plan 04) — this fix is upstream of it on
+  the model path and orthogonal on the TUI path.
+- Not a rewrite of `metadata` semantics for other tools; only its size on the
+  model-facing message is bounded.
+
+## Design
+
+Two layers; layer 1 is the fix, layer 2 is defense-in-depth.
+
+### Layer 1 — model-facing serialization excludes heavy metadata (the fix)
+
+Add a sibling to `result_to_json` in `src/core/tool_contract.ail`:
+
+```
+-- Model-facing serialization. Same shape as result_to_json MINUS the heavy,
+-- harness-only keys. The model needs stdout/stderr/exit_code (stdout is the
+-- already-capped scratchpad transcript with [image: path] refs); it never
+-- needs the raw cells/base64 — those go to the TUI via scratchpad_result.
+export func result_to_model_json(result: ToolResultEnvelope) -> Json {
+  jo([
+    kv("tool_call_id", js(result.tool_call_id)),
+    kv("tool",         js(result.tool)),
+    kv("exit_code",    jnum(_int_to_float(result.exit_code))),
+    kv("stdout",       js(result.stdout)),
+    kv("stderr",       js(result.stderr)),
+    kv("metadata",     sanitize_model_metadata(result.metadata))
+  ])
+}
+```
+
+`sanitize_model_metadata` drops the known-heavy keys (`cells`, `images`,
+`jsonOutputs`) and keeps the small scalar keys some tools rely on (e.g. the
+`error`/`message` flags set in `tool_envelope_dispatch.ail:20`). Simplest robust
+form: rebuild the object from an allowlist of small keys, or strip the denylist
+`["cells","images","jsonOutputs"]`.
+
+Then change the two model-message construction sites to use it:
+- `agent_loop_v2.ail:776` (scratchpad-handled branch)
+- `agent_loop_v2.ail:799` (generic `Handled` branch)
+
+`emit_scratchpad_result_if_present` is called **before** both sites
+(`:773`, `:792`) with the full `result_env`, so the TUI event is unaffected.
+
+### Layer 2 — absolute size cap on any tool message content (belt & suspenders)
+
+Even with heavy keys removed, a future tool could return a multi-MB `stdout` or
+metadata scalar. Add a single bound when building the tool `Message.content`: if
+the encoded content exceeds a cap (e.g. 64 KB), truncate with a explicit marker
+(`…[truncated N bytes]`). One helper applied at both sites (and ideally the
+Native path, see Audit) guarantees no tool can exceed the budget.
+
+### Audit (systemic)
+
+Grep for every place a tool result becomes a `Message.content` and confirm the
+bound applies or the path can't carry large metadata:
+- `agent_loop_v2.ail:776`, `:799` — fixed by layer 1+2.
+- `agent_loop_v2.ail:744` `tool_result_message(call, result_content)` (Native
+  path) — `result_content` is a string from `dispatch_one`; confirm it's already
+  bounded or apply the layer-2 cap.
+- Delegated/deferred path — confirm results route through the env-server caps.
+
+## Implementation steps
+
+1. `src/core/tool_contract.ail`: add `result_to_model_json` +
+   `sanitize_model_metadata` (denylist `cells`/`images`/`jsonOutputs`). Keep
+   `result_to_json` as-is for any non-model consumer.
+2. `src/core/agent_loop_v2.ail`: swap `result_to_json` → `result_to_model_json`
+   at `:776` and `:799`. Leave `emit_scratchpad_result_if_present` untouched.
+3. Add the layer-2 content cap helper and apply it where tool `Message.content`
+   is built.
+4. (Optional, separate) `env-server.ts` `spillImages`/response: drop
+   `displays[].data` base64 from `cells` **only if** a TUI-only field retains it
+   — DO NOT do this unless inline rendering is confirmed to read from a separate
+   field, since `cells_json` currently needs the base64. Default: skip; layer 1
+   already fixes the leak.
+
+All changes are interpreted `src/core/*.ail` — **no Go rebuild**; restart Motoko
+(and clear `src/core/.ailang/cache` if stale) to pick them up.
+
+## Testing
+
+- **AILANG unit (`tool_contract`):** `result_to_model_json` on an envelope whose
+  `metadata` has `cells`/`images` plus a small `error` scalar → output omits
+  `cells`/`images`, keeps `error`, keeps `stdout`/`stderr`/`exit_code`.
+- **AILANG unit (cap):** content > cap → truncated with marker; ≤ cap → verbatim.
+- **TS regression (`env-server`/transcript):** `buildScratchpadTranscript` still
+  emits `[image: path]` refs and stays ≤ 50 KB (unchanged).
+- **Integration / smoke:** run a scratchpad cell that emits a plot under
+  `PROFILE=bedrock` (`gpt-bedrock-opus-4-8`); assert (a) the TUI still renders the
+  image (`scratchpad_result`/`cells_json` intact, base64 present) and (b) the
+  model tool message size is small (no base64) — inspect
+  `.motoko/logfile/*.jsonl`. Re-run the original failing scenario; assert no
+  `ContextWindowExceededError`.
+
+## Acceptance criteria
+
+- Reproduction scenario completes without `ContextWindowExceededError`.
+- Model-facing scratchpad tool message contains the capped transcript and **no**
+  base64 / raw `cells`; size bounded by the layer-2 cap.
+- `scratchpad_result` TUI event unchanged (full `cells` incl. base64); inline
+  image rendering (plan 04) unaffected.
+- No Go/binary changes; fix is in interpreted `.ail` (+ optional TS test).
+
+## Risks / notes
+
+- **Don't strip base64 from the TUI path.** The whole point of plan 04 is that
+  base64 reaches the TUI; stripping it at env-server or in `metadata.cells`
+  regresses inline images. The split must be brain-side (model vs TUI).
+- Some tools read small `metadata` keys downstream; `sanitize_model_metadata`
+  must preserve scalars (allowlist or targeted denylist), not nuke `metadata`.
+- Operational stopgap until shipped: avoid image-heavy scratchpad cells on
+  large-context-sensitive models, or drop `scratchpad` from
+  `extensions.order` in the bedrock profile.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,14 @@ src/tui/dist/
 
 # Generated build artifacts
 .packages/
+
+# Local AILANG source checkout used to build a patched binary (e.g. the Bedrock
+# OPENAI_BASE_URL direct-fallback fix). Its own git repo + ailang/.bin/ailang
+# build artifact must never be committed into motoko_agent.
+/ailang/
 # Environment
 .env
+.venv-litellm/
 
 # OS
 .DS_Store

--- a/ailang.lock
+++ b/ailang.lock
@@ -1,6 +1,6 @@
 {
   "ailang_version": "v0.24.2",
-  "generated_at": "2026-06-20T16:26:04.376013772Z",
+  "generated_at": "2026-06-21T12:00:58.941848763Z",
   "generator": "ailang lock v0.24.2",
   "packages": [
     {

--- a/src/core/agent_loop_v2.ail
+++ b/src/core/agent_loop_v2.ail
@@ -47,7 +47,7 @@ import std/process (exec, ProcessError, ProcessOutput)
 import std/bytes (toString)
 import std/trace as Trace
 import src/core/tool_catalog (tools_with_extensions)
-import src/core/tool_contract (ToolResultEnvelope, call_to_json, result_to_json)
+import src/core/tool_contract (ToolResultEnvelope, call_to_json, result_to_model_json)
 import src/core/parse (extract_bash)
 import src/core/tool_dispatch_adapter (dispatch_one, tool_call_to_envelope)
 import src/core/tool_runtime (backend_for_v2)
@@ -363,13 +363,52 @@ func step_result_to_message(result: StepResult) -> Message {
   }
 }
 
+pure func cap_tool_message_content(content: string) -> string {
+  let cap = 65536;
+  let n = Str.length(content);
+  if n <= cap then content
+  else {
+    let marker = "\n...[truncated; original ${show(n)} bytes]";
+    let keep = cap - Str.length(marker);
+    "${substring(content, 0, keep)}${marker}"
+  }
+}
+
+pure func test_cap_tool_message_content_keeps_small_content() -> bool
+  tests [((), true)]
+  {
+    cap_tool_message_content("small result") == "small result"
+  }
+
+pure func test_cap_tool_message_content_truncates_oversized_content() -> bool
+  tests [((), true)]
+  {
+    let x1 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB";
+    let x2 = "${x1}${x1}";
+    let x4 = "${x2}${x2}";
+    let x8 = "${x4}${x4}";
+    let x16 = "${x8}${x8}";
+    let x32 = "${x16}${x16}";
+    let x64 = "${x32}${x32}";
+    let x128 = "${x64}${x64}";
+    let x256 = "${x128}${x128}";
+    let x512 = "${x256}${x256}";
+    let x1024 = "${x512}${x512}";
+    let capped = cap_tool_message_content(x1024);
+    Str.length(capped) == 65536 && contains(capped, "...[truncated; original ")
+  }
+
+func result_env_model_content(result: ToolResultEnvelope) -> string {
+  cap_tool_message_content(encode(result_to_model_json(result)))
+}
+
 -- Build a tool-role Message containing a dispatcher result. The tool_call_id
 -- field is the load-bearing wire-format requirement: Anthropic / OpenAI /
 -- Gemini all correlate tool_use → tool_result by this id.
 func tool_result_message(call: ToolCall, content: string) -> Message {
   {
     role: "tool",
-    content: content,
+    content: cap_tool_message_content(content),
     tool_calls: [],
     tool_call_id: call.id
   }
@@ -383,7 +422,7 @@ func tool_result_message(call: ToolCall, content: string) -> Message {
 func envelope_to_tool_message(envelope: ToolResultEnvelope) -> Message {
   {
     role: "tool",
-    content: encode(result_to_json(envelope)),
+    content: result_env_model_content(envelope),
     tool_calls: [],
     tool_call_id: envelope.tool_call_id
   }
@@ -709,7 +748,7 @@ func dispatch_calls(
                   let _ = emit_scratchpad_result_if_present(session_id, "step-${show(step_idx)}", step_idx, call.id, result_env);
                   let handled_msg: Message = {
                     role: "tool",
-                    content: encode(result_to_json(result_env)),
+                    content: result_env_model_content(result_env),
                     tool_calls: [],
                     tool_call_id: call.id
                   };
@@ -773,7 +812,7 @@ func dispatch_calls(
             let _ = emit_scratchpad_result_if_present(session_id, "step-${show(step_idx)}", step_idx, call.id, result_env);
             let handled_msg: Message = {
               role: "tool",
-              content: encode(result_to_json(result_env)),
+              content: result_env_model_content(result_env),
               tool_calls: [],
               tool_call_id: call.id
             };
@@ -796,7 +835,7 @@ func dispatch_calls(
               -- extension-internal id.
               let handled_msg: Message = {
                 role: "tool",
-                content: encode(result_to_json(result_env)),
+                content: result_env_model_content(result_env),
                 tool_calls: [],
                 tool_call_id: call.id
               };

--- a/src/core/tool_contract.ail
+++ b/src/core/tool_contract.ail
@@ -1,7 +1,7 @@
 module src/core/tool_contract
 
 import std/option (Option, Some, None)
-import std/json (Json, jo, kv, js, jnum, jb, get, asString, asNumber, asBool, asArray)
+import std/json (Json, JObject, JBool, JString, jo, kv, js, jnum, jb, get, asString, asNumber, asBool, asArray)
 
 export type ToolCallEnvelope = {
   id: string,
@@ -36,6 +36,35 @@ export func result_to_json(result: ToolResultEnvelope) -> Json {
     kv("stdout", js(result.stdout)),
     kv("stderr", js(result.stderr)),
     kv("metadata", result.metadata)
+  ])
+}
+
+export pure func sanitize_model_metadata(metadata: Json) -> Json {
+  match metadata {
+    JObject(kvs) => JObject(sanitize_model_metadata_kvs(kvs)),
+    _ => metadata
+  }
+}
+
+pure func sanitize_model_metadata_kvs(kvs: [{key: string, value: Json}]) -> [{key: string, value: Json}] {
+  match kvs {
+    [] => [],
+    x :: rest =>
+      if x.key == "cells" || x.key == "images" || x.key == "jsonOutputs" then
+        sanitize_model_metadata_kvs(rest)
+      else
+        x :: sanitize_model_metadata_kvs(rest)
+  }
+}
+
+export pure func result_to_model_json(result: ToolResultEnvelope) -> Json {
+  jo([
+    kv("tool_call_id", js(result.tool_call_id)),
+    kv("tool", js(result.tool)),
+    kv("exit_code", jnum(_int_to_float(result.exit_code))),
+    kv("stdout", js(result.stdout)),
+    kv("stderr", js(result.stderr)),
+    kv("metadata", sanitize_model_metadata(result.metadata))
   ])
 }
 
@@ -101,3 +130,43 @@ func string_list_rec(xs: [Json]) -> [string] {
       }
   }
 }
+
+pure func json_has_key(obj: Json, key: string) -> bool {
+  match get(obj, key) {
+    None => false,
+    Some(_) => true
+  }
+}
+
+pure func test_result_to_model_json_strips_heavy_metadata() -> bool
+  tests [((), true)]
+  {
+    let result: ToolResultEnvelope = {
+      tool_call_id: "call-1",
+      tool: "scratchpad",
+      exit_code: 0,
+      stdout: "[image: /tmp/plot.png (640x480 image/png)]",
+      stderr: "",
+      metadata: jo([
+        kv("cells", js("raw-cell-payload")),
+        kv("images", js("raw-image-payload")),
+        kv("jsonOutputs", js("raw-json-payload")),
+        kv("error", jb(false)),
+        kv("message", js("ok"))
+      ])
+    };
+    match get(result_to_model_json(result), "metadata") {
+      None => false,
+      Some(meta) =>
+        not json_has_key(meta, "cells")
+          && not json_has_key(meta, "images")
+          && not json_has_key(meta, "jsonOutputs")
+          && match get(meta, "error") {
+            Some(JBool(false)) => match get(meta, "message") {
+              Some(JString("ok")) => true,
+              _ => false
+            },
+            _ => false
+          }
+    }
+  }


### PR DESCRIPTION
# Fix Scratchpad Graph Output Spilling Into Model Context

Base branch: `origin/main`

## Summary

This branch fixes a context-window blow-up caused by scratchpad graph/image
results being sent back to the model as raw tool-result metadata.

Scratchpad output has two consumers:

- the TUI, which needs full cell payloads including image base64 so it can
  render inline graphs;
- the model, which only needs a compact observation with stdout/stderr,
  exit code, and `[image: path]` references.

Before this change, the model-facing tool message used the same full
`ToolResultEnvelope` serialization as internal/TUI paths. That meant
`metadata.cells` could include large ANSI/image bundles and PNG base64, causing
image-heavy scratchpad runs to re-enter the prompt and risk
`ContextWindowExceededError`.

## Changes

- Add `result_to_model_json` in `src/core/tool_contract.ail` for model-facing
  tool result serialization.
- Strip known-heavy metadata keys from model-facing results:
  - `cells`
  - `images`
  - `jsonOutputs`
- Keep regular `result_to_json` unchanged for non-model consumers.
- Route extension-handled scratchpad/tool results in `agent_loop_v2.ail` through
  the new model serializer.
- Keep `emit_scratchpad_result_if_present` unchanged, so `scratchpad_result`
  still carries full `cells_json` with base64 to the TUI.
- Add a 64 KB hard cap for all tool-role `Message.content` strings, including
  native dispatch results, as defense in depth.
- Add inline AILANG regression tests for:
  - model serialization dropping heavy metadata while preserving scalar fields;
  - tool message content capping behavior.
- Add the implementation plan documenting the root cause and acceptance criteria.
- Update `.gitignore` for local development artifacts:
  - `/ailang/`
  - `.venv-litellm/`
- Refresh `ailang.lock` timestamp from the local lock generation.

## User Impact

Scratchpad graph/image runs no longer send raw cell payloads or PNG base64 back
to the model. The model now receives a small observation like:

```json
{
  "tool": "scratchpad",
  "exit_code": 0,
  "stdout": "",
  "stderr": "",
  "metadata": {
    "stdout": "== py cell 1 ==\n[image: .motoko/artifacts/core_ext_v2/cell1-1.png (image/png)]\n[done: exit=0 count=3]",
    "stderr": ""
  }
}
```

The TUI still receives full scratchpad cells for inline rendering, so graph
display behavior is preserved.

## Verification

- `ailang check src/core/tool_contract.ail`
- `ailang test src/core/tool_contract.ail`
- `ailang check src/core/agent_loop_v2.ail`
- `ailang test src/core/agent_loop_v2.ail`
- Manual scratchpad graph run with the `scratchpad` extension active.

Manual log inspection of
`.motoko/logfile/session_2026-06-21T12-01-36-774Z.jsonl` confirmed the split:

- `scratchpad_result` events still contained PNG base64 for the TUI:
  - line 55: `107,961` bytes, `has_iVBOR=true`
  - line 296: `348,421` bytes, `has_iVBOR=true`
  - line 445: `307,855` bytes, `has_iVBOR=true`
- model-facing `native_tool_results` events were small and contained no raw
  image/cell payloads:
  - line 56: `528` bytes, `has_iVBOR=false`, no `cells`, no `images`, no
    `jsonOutputs`
  - line 297: `534` bytes, same
  - line 446: `528` bytes, same

Note: AILANG check/test commands emitted unrelated ClickStack trace export
`401 Unauthorized` warnings after successful completion.
