### PR TITLE
arniwesth/mot 17 reenable gracefull esc steering capability

### DIFF
--- a/.agent/plans/steering_capability/Abort_Context_Persistence_Option_A.md
+++ b/.agent/plans/steering_capability/Abort_Context_Persistence_Option_A.md
@@ -3,6 +3,25 @@
 Fixes GitHub issue **#15 — "Aborting (Esc) in the middle of a task flushes the
 context window."**
 
+## TL;DR
+
+- **Bug:** ESC mid-task calls `runtimeProcess.kill()` (SIGTERM). The conversation
+  lives only in the runtime's memory (`loop_v2`'s `[Message]` param), so the kill
+  destroys it and the next prompt respawns a fresh, empty process. Regression from the
+  v2 loop rewrite.
+- **Why not just keep the process alive (Option B):** grounded against the AILANG MCP,
+  `std/io` has only blocking `readLine` — no non-blocking/poll stdin in v0.24.2 — so a
+  blocking in-flight step can only be interrupted by killing the process. Surviving that
+  requires persisting history to disk.
+- **Fix (Option A):** (1) TS passes a stable `MOTOKO_SESSION_ID` across respawns;
+  (2) AILANG checkpoints `[Message]` history to `${workdir}/.motoko/session/<id>.json`
+  after each step via sandboxed `std/fs`; (3) on `MOTOKO_RESUME=1` respawn the runtime
+  rehydrates from the checkpoint into `conversation_loop_v2`, and the post-ESC prompt
+  arrives as a follow-up `user_message`. Checkpoint is deleted on clean exit.
+- **Works on current AILANG v0.24.2**, no upstream change. Three independently
+  landable/revertible patches. Follow-up: file upstream feedback for non-blocking stdin
+  to unlock the cleaner Option B later.
+
 ## Background
 
 Pressing **ESC** mid-task wipes the conversation. Repro (from the issue): start a
@@ -95,11 +114,14 @@ Three coordinated changes:
    `MOTOKO_SESSION_ID` is only set by the eval adapter; interactive runs fall back to
    `session_${now()}`, which differs per process — unusable as a stable key.)
 
-2. **Checkpoint after each step (AILANG).** `loop_v2` serializes its `[Message]`
-   history to `${workdir}/.motoko/session/<session_id>.json` after each step, and
-   `conversation_loop_v2` re-checkpoints after each completed turn. Writes are
-   atomic-ish (write temp + rename via two `std/fs` calls, or accept truncating
-   `writeFile` since a step boundary is a consistent point).
+2. **Checkpoint at each step boundary (AILANG).** `loop_v2` serializes its incoming
+   `[Message]` history to `${workdir}/.motoko/session/<session_id>.json` once at the top
+   of the loop (covers every step including step 0), and `conversation_loop_v2`
+   re-checkpoints after each completed turn. `std/fs` has **no `rename`**, so a
+   write-temp-then-rename atomic swap isn't available; we accept a truncating
+   `writeFile` (a step boundary is a consistent snapshot point) and handle the only real
+   risk — a SIGTERM landing mid-`writeFile` — on the **read** side via `std/json.repair`
+   + best-effort fallback (Patch 2a/3b).
 
 3. **Resume on respawn (AILANG + TS).** When the TUI respawns after ESC, it sets
    `MOTOKO_RESUME=1`. `run_with_config` checks for the checkpoint; if present and
@@ -153,23 +175,69 @@ On `/restart`, mint a new `sessionId` (it's a genuinely new session).
 
 ### 2a. Message ↔ JSON round-trip
 
-The file already serializes tool results (`tool_messages_to_result_jsons`,
-`:544`) and converts `[Msg]`↔`[Message]` (`msgs_to_messages` `:342`,
-`messages_to_msgs` `:468`). Add a faithful full-`Message` codec covering all four
-fields (`role`, `content`, `tool_calls`, `tool_call_id`):
+**Grounded type shapes (from the AILANG MCP, `std/ai`):**
+
+- `Message = { role: string, content: string, tool_calls: [ToolCall], tool_call_id: string }`
+- `ToolCall = { id: string, name: string, arguments: string }` — `arguments` is a
+  **JSON-encoded string**, not a `Json`. (Confirmed by the record literal at
+  `agent_loop_v2.ail:588-593`; do **not** confuse with `tool_contract.ToolCallEnvelope`,
+  whose `arguments` is a `Json`.)
+
+Both are plain records, so a `ToolCall` is reconstructable in user code via a record
+literal — the codec is feasible. Add it to `agent_loop_v2.ail` (the only module that
+imports `Message`/`ToolCall`; rpc.ail must stay codec-free, see 3b).
+
+Write encoders/decoders as **explicit recursion**, matching the existing
+`messages_to_msgs` (`:468`) idiom — avoid `map`+lambda (the file notes a match-in-lambda
+parser bug at `:1125`).
 
 ```ailang
-func message_to_json(m: Message) -> Json { ... }      -- includes tool_calls array
-func messages_to_json(ms: [Message]) -> Json { ja(map(message_to_json, ms)) }
-func json_to_message(j: Json) -> Message { ... }
-func json_to_messages(j: Json) -> [Message] { ... }   -- tolerant of missing fields
+-- encode
+func tool_call_to_json(tc: ToolCall) -> Json {
+  jo([kv("id", js(tc.id)), kv("name", js(tc.name)), kv("arguments", js(tc.arguments))])
+}
+func tool_calls_to_json(tcs: [ToolCall]) -> [Json] {
+  match tcs { [] => [], h :: t => tool_call_to_json(h) :: tool_calls_to_json(t) }
+}
+func message_to_json(m: Message) -> Json {
+  jo([
+    kv("role", js(m.role)),
+    kv("content", js(m.content)),
+    kv("tool_calls", ja(tool_calls_to_json(m.tool_calls))),
+    kv("tool_call_id", js(m.tool_call_id))
+  ])
+}
+func messages_to_json(ms: [Message]) -> [Json] {
+  match ms { [] => [], h :: t => message_to_json(h) :: messages_to_json(t) }
+}
+
+-- decode (tolerant: missing fields default to "" / [])
+--   reuse the file's existing msg_get_str (get + asString, "" fallback, :495);
+--   add getArray to the std/json import list (:41) for the tool_calls / messages arrays.
+func json_to_tool_call(j: Json) -> ToolCall {
+  { id: msg_get_str(j, "id"), name: msg_get_str(j, "name"),
+    arguments: msg_get_str(j, "arguments") }
+}
+func json_to_message(j: Json) -> Message {
+  { role: msg_get_str(j, "role"), content: msg_get_str(j, "content"),
+    tool_calls: <getArray(j,"tool_calls") |> recurse json_to_tool_call, [] if None>,
+    tool_call_id: msg_get_str(j, "tool_call_id") }
+}
+func json_to_messages(j: Json) -> [Message] {
+  -- getArray(j, "messages") -> Option[List[Json]]; None/empty => []; else map json_to_message via explicit recursion
+  ...
+}
 ```
 
-`tool_calls` must round-trip (id, name, arguments) — reuse whatever ToolCall JSON
-shape `step_result_to_message` / the hybrid path already build (`:1246-1251`) so the
-restored history is accepted by every provider (the Bedrock tool_use correlation note
-at `:1228-1245` applies — a restored assistant message with tool_calls must keep its
-`tool_call_id` correlation intact).
+`tool_calls` **must** round-trip (id, name, arguments) so restored assistant messages
+keep their `tool_call_id` correlation — the Bedrock note at `:1228-1245` applies: a
+restored assistant message carrying tool_calls whose ids don't match the following
+tool-role messages is rejected with HTTP 400. The round-trip test (below) is the guard.
+
+**Robustness:** if `decode` of a checkpoint truncated by a mid-write kill fails, retry
+once via `std/json.repair` before giving up — `repair` handles unclosed
+arrays/objects/strings, which is exactly the truncation a SIGTERM mid-`writeFile` can
+produce.
 
 ### 2b. Checkpoint helper
 
@@ -181,9 +249,9 @@ func checkpoint_path(workdir: string, session_id: string) -> string {
 func write_checkpoint(workdir: string, session_id: string, msgs: [Message]) -> () ! {FS} {
   let _ = mkdirAllResult("${workdir}/.motoko/session");
   let body = encode(jo([
-    kv("schema_version", jnum(1.0)),
+    kv("schema_version", jnum(_int_to_float(1))),  -- match the file's jnum idiom
     kv("session_id", js(session_id)),
-    kv("messages", messages_to_json(msgs))
+    kv("messages", ja(messages_to_json(msgs)))     -- messages_to_json returns [Json]
   ]));
   -- writeFileResult so a checkpoint failure never aborts the task.
   let _ = writeFileResult(checkpoint_path(workdir, session_id), body);
@@ -192,25 +260,64 @@ func write_checkpoint(workdir: string, session_id: string, msgs: [Message]) -> (
 ```
 
 Use the `Result` variants (`writeFileResult`, `mkdirAllResult`) so a disk error
-degrades to "no checkpoint" rather than killing the run.
+degrades to "no checkpoint" rather than killing the run. `writeFile` does **not** create
+parent dirs (per the std/fs doc — "future enhancement"), so the `mkdirAllResult` call is
+required, not optional.
 
-### 2c. Call sites
+**Sandbox alignment.** The runtime's FS is restricted to `AILANG_FS_SANDBOX = workdir`
+(`runtime-process.ts:308`), and `workdir` here is `cwd` from `run_with_config`
+(`= inv.workdir_override || cfg.agent.workdir`). The checkpoint path is under that root,
+so writes are permitted. The TS cleanup (3c) must target the **same** `workdir` the
+runtime was given.
 
-- In `loop_v2`, after each step's history is finalized and **before** the recursive
-  call (every branch that recurses with `next_msgs` — e.g. `:1211`, `:1255`, and the
-  typed-tool-calls dispatch branch), call
-  `write_checkpoint(workdir, session_id, next_msgs)`. Centralize by writing once at the
-  point `next_msgs` is computed, or wrap the recursion in a small helper that
-  checkpoints then recurses.
-- In `conversation_loop_v2`, after a turn returns `Ok(updated_history)` (`:1553`),
-  `write_checkpoint(workdir, session_id, updated_history)` before recursing.
+### 2c. Call site — one checkpoint at the top of `loop_v2`
 
-`loop_v2` and `conversation_loop_v2` already declare the `FS` effect, so no signature
-changes. `workdir` and `session_id` are already in scope in both.
+`loop_v2` recurses from **seven** distinct branches (verified:
+`:1211, :1255, :1283, :1299, :1322, :1338, :1374`). Checkpointing before each recursion
+would mean seven edits and a standing risk that a future branch is added without one.
 
-**Frequency / cost:** one truncating write per step of the full message list. For
-typical step counts and message sizes this is negligible; if it ever matters, switch to
-append-only JSONL deltas. Not needed now.
+**Instead, checkpoint the incoming `msgs` once, at the top of `loop_v2`** — at the start
+of the main `else` block (`agent_loop_v2.ail:1075`, just before
+`let ctx = mk_v2_ext_ctx(...)`):
+
+```ailang
+else {
+  let _ = write_checkpoint(workdir, session_id, msgs);   -- NEW: snapshot pre-step state
+  let ctx = mk_v2_ext_ctx(task, step_idx, model, workdir, env_url, hybrid_tools, budget, msgs);
+  ...
+```
+
+This single site captures the full history at **every** step boundary including
+**step 0** (where `msgs` is the initial `[system, user-task]`). Two consequences:
+
+1. It covers all seven recursion branches automatically — the next iteration's
+   pre-step snapshot *is* the previous iteration's `next_msgs`.
+2. It fixes the exact issue scenario: an ESC ~55 s in (likely during step 0/1) still
+   leaves a checkpoint containing the original task + system prompt, so the follow-up
+   "what was my last prompt?" can answer.
+
+The documented non-goal stands: the checkpoint reflects state **before** the in-flight
+step's LLM call, so the interrupted step's own (incomplete) output is not recovered.
+
+**Secondary checkpoint (belt-and-suspenders):** in `conversation_loop_v2`, after a turn
+returns `Ok(updated_history)` (`:1553`), call
+`write_checkpoint(workdir, session_id, updated_history)` before recursing — so a
+*completed* task's final assistant turn is on disk even before the next turn's first
+step would re-snapshot it. Low cost, closes the "killed while idle after done" gap.
+
+`loop_v2` and `conversation_loop_v2` already declare the `FS` effect and already have
+`workdir` + `session_id` in scope, so no signature changes.
+
+**Consistency note (depends on Patch 1).** `loop_v2`'s `session_id` comes from
+`run_v2_from_messages`'s own `derive_session_id()` call (`:1440`), while
+`conversation_loop_v2`'s comes from `run_v2_with_conversation`'s separate
+`derive_session_id()` (`:1591`). These agree **only** when `MOTOKO_SESSION_ID` is set —
+which is exactly what Patch 1 guarantees. Without Patch 1 the two would diverge and the
+secondary checkpoint would write to a different file than the primary. Patch 1 is a hard
+prerequisite for Patch 2, not just Patch 3.
+
+**Frequency / cost:** one truncating write of the full message list per step. Negligible
+for typical sizes; switch to append-only deltas only if it ever shows up in profiling.
 
 ---
 
@@ -220,70 +327,107 @@ append-only JSONL deltas. Not needed now.
 
 **File:** `src/tui/src/index.ts`
 
-The interrupted-respawn path is the `setAwaitingTask(true)` branch at `:932-935`. The
-next submission currently calls `onInitialTask → spawnRuntimeProcess(value, true)`.
-Change the respawn after an interrupt to pass a resume flag so the new process
-rehydrates instead of starting the task fresh:
+Currently the interrupt branch (`index.ts:932-935`) sets `interrupted=false` and calls
+`ui.setAwaitingTask(true)`, so the next plain submission routes through `onInitialTask →
+spawnRuntimeProcess(value, true)` — a fresh task. Two changes:
 
-- Set `MOTOKO_RESUME=1` in the child env for respawns that follow an interrupt
-  (thread a `resume: boolean` through `spawnRuntimeProcess` / `RuntimeProcess`, exported
-  alongside `MOTOKO_SESSION_ID` in `runtime-process.ts`).
-- The post-ESC first submission should be delivered as a **`user_message`** on the
-  resumed session, not as the initial `task`. Concretely: after an interrupt, the
-  respawn happens immediately (empty task) with `MOTOKO_RESUME=1`; the runtime
-  rehydrates and enters `conversation_loop_v2` waiting on stdin; the user's next line is
-  sent via `runtimeProcess.sendUserMessage(...)` (the `taskDone`/follow-up path,
-  `ui.ts:4009-4017`), exactly like a normal follow-up after `done`.
+**(i) Respawn immediately with resume, instead of awaiting a fresh task.** Mirror the
+existing restart branch's deferred respawn (`index.ts:931`):
 
-  This means after ESC the UI should transition to the **follow-up** state
-  (`taskDone = true`) rather than the **awaiting-initial-task** state, so plain text
-  routes to `onUserMessage` not `onInitialTask`. Adjust the interrupt branch at
-  `index.ts:932-935` accordingly (e.g. respawn with resume immediately, then
-  `ui.setTaskDone(true)` once the resumed process signals it is ready).
+```ts
+} else if (interrupted) {
+  interrupted = false;
+  // Respawn immediately and resume the checkpointed history; the user's next
+  // line will arrive as a follow-up user_message, not a new task.
+  setTimeout(() => spawnRuntimeProcess("", false, /* resume */ true), 100);
+}
+```
+
+Thread a third `resume?: boolean` arg through `spawnRuntimeProcess` →
+`RuntimeProcess`, exported as `MOTOKO_RESUME=1` in the child env alongside
+`MOTOKO_SESSION_ID` (env allowlist, `runtime-process.ts:300-330`). Default off, so every
+other spawn path is unchanged.
+
+**(ii) Enable follow-up input via the `session_resume` event, not a public setter.**
+There is no public `setTaskDone` — `taskDone` is private and is flipped inside the event
+handlers (e.g. the `done` path at `ui.ts:2730-2732`). So handle the new `session_resume`
+event in `ui.handleEvent` the same way `done` is handled: set `taskDone = true`,
+`setRunState("idle")`, render a "Resumed N messages" line. That puts the UI in the
+**follow-up** state, so plain text routes to `onUserMessage → sendUserMessage(...)`
+(`ui.ts:4009-4017`) — exactly a normal post-`done` follow-up. The resumed runtime is
+already blocking in `conversation_loop_v2`'s `readLine()`, ready to receive it.
+
+Do **not** call `setAwaitingTask(true)` on the interrupt path anymore (that would route
+the next line to `onInitialTask`, starting a fresh task and defeating the resume).
+
+> TTY/headless check: the respawned child's `MOTOKO_HEADLESS` is derived from the
+> **parent TUI's** `process.stdin.isTTY` (`runtime-process.ts:317-319`), which stays a
+> TTY across respawn — so `conversation_loop_v2` runs its `readLine()` loop (not the
+> headless early-exit). Resume works in interactive mode; headless/eval runs never set
+> `MOTOKO_RESUME` and are unaffected.
 
 ### 3b. AILANG — load checkpoint and enter the conversation loop
 
-**File:** `src/core/rpc.ail` (`run_with_config`, `:156-238`)
+Keep all `Message`/JSON/checkpoint logic **inside `agent_loop_v2.ail`** — `rpc.ail` does
+not import `Message` and must not start to. rpc.ail only decides *whether* to resume and
+calls the right entry.
 
-Before building the fresh `init` task, check for resume:
-
-```ailang
-let resume = getEnvOr("MOTOKO_RESUME", "") == "1";
-let session_id = getEnvOr("MOTOKO_SESSION_ID", "");
-let ckpt = "${cwd}/.motoko/session/${session_id}.json";
-```
-
-If `resume && session_id != "" && fileExists(ckpt)`:
-
-- Read + decode the checkpoint, `json_to_messages` → restored `[Message]`.
-- Emit a `session_resume` event (new event type; mirror `session_start` fields plus
-  `restored_messages: <count>`) so the TUI/logger can show "resumed N messages".
-- Call a new exported entry `resume_v2_conversation(rt, env_url, ..., restored_history,
-  ...)` that **skips the initial run** and goes straight to `conversation_loop_v2` with
-  the restored history. This reuses the existing `conversation_loop_v2` verbatim.
-- On decode failure or empty/missing checkpoint, **fall through** to the normal fresh
-  `init` path (resume is best-effort, never fatal).
-
-Otherwise: the existing `run_v2_with_conversation(... init ...)` path, unchanged.
-
-Add the `resume_v2_conversation` wrapper next to `run_v2_with_conversation`
-(`agent_loop_v2.ail:1576`) — it is `run_v2_with_conversation` minus the initial
-`run_v2_from_messages` call:
+**`agent_loop_v2.ail` — new exports:**
 
 ```ailang
+-- Best-effort load; None on missing/corrupt (after one std/json.repair retry).
+export func try_load_checkpoint(workdir: string, session_id: string)
+  -> Option[[Message]] ! {FS} { ... readFileResult → decode/repair → json_to_messages ... }
+
+-- conversation_loop_v2 entry from a restored history; emits session_resume.
+-- `fallback_init` is used only if the checkpoint vanished/decoded empty between
+-- rpc.ail's fileExists check and this read (tiny race) — never silently start blank.
 export func resume_v2_conversation(
   rt, env_url, hybrid_tools, budget, model,
-  restored_history: [Message], workdir, step_budget, ohmy_pi,
+  fallback_init: [Msg], workdir, step_budget, ohmy_pi,   -- [Msg] in, like run_v2_with_conversation
   max_cost_millicents, cost_rates, provider, session_id
 ) -> () ! {AI, FS, Process, IO, Env, Net, SharedMem, Clock, Stream, Trace} {
+  let history = match try_load_checkpoint(workdir, session_id) {
+    Some(restored) => restored,
+    None           => msgs_to_messages(fallback_init)  -- race/corrupt: never start blank
+  };
+  let _ = emit_event(session_id, "session_resume", [
+    kv("model", js(model)),
+    kv("restored_messages", jnum(_int_to_float(List.length(history))))
+  ]);
   conversation_loop_v2(rt, env_url, hybrid_tools, budget, model,
-    restored_history, workdir, step_budget, ohmy_pi,
+    history, workdir, step_budget, ohmy_pi,
     max_cost_millicents, cost_rates, provider, session_id)
 }
 ```
 
-Note: pass `session_id` explicitly (don't re-`derive_session_id()`) so the checkpoint
-key stays stable across the resumed turns.
+`session_id` is passed in explicitly (don't re-`derive_session_id()`), keeping the
+checkpoint key stable across resumed turns.
+
+**`src/core/rpc.ail` (`run_with_config`, `:156-238`) — gate the entry:**
+
+```ailang
+let session_id = getEnvOr("MOTOKO_SESSION_ID", "");
+let resume = getEnvOr("MOTOKO_RESUME", "") == "1"
+          && session_id != ""
+          && fileExists("${cwd}/.motoko/session/${session_id}.json");
+```
+
+- **Resume path:** skip the unconditional `session_start` emit (`rpc.ail:~180-191`) —
+  emit nothing here; `resume_v2_conversation` emits `session_resume` instead. Then call
+  `resume_v2_conversation(ext_runtime, env_url, ..., init, settings.workdir, ...,
+  session_id)`, passing the freshly-built `init` as the fallback.
+- **Normal path (unchanged):** emit `session_start` as today, then
+  `run_v2_with_conversation(... init ...)`.
+
+So `session_start` and `session_resume` are mutually exclusive — the TUI never sees both
+for one respawn, and never double-counts a session.
+
+**Required new import in `rpc.ail`:** `std/env (getEnvOr)` (rpc.ail does not currently
+import it). `fileExists` is already imported (`rpc.ail:21`). rpc.ail keeps passing the
+`init: [Msg]` it builds at `:228` unchanged — `resume_v2_conversation` takes `[Msg]` and
+converts via `msgs_to_messages` internally (same as `run_v2_with_conversation` at
+`:1591`), so rpc.ail stays codec-free.
 
 ### 3c. Normal-exit cleanup
 
@@ -320,12 +464,17 @@ No other protocol changes.
   `tool_call_id` survives encode→decode unchanged (field-by-field).
 - `write_checkpoint` then read-back: assert the file at `checkpoint_path` decodes to the
   same messages.
-- Resume entry: given a checkpoint on disk and `MOTOKO_RESUME=1` +
-  `MOTOKO_SESSION_ID`, `run_with_config` enters the resume path (assert a
-  `session_resume` event is emitted with the right `restored_messages` count) and does
-  **not** emit a fresh-task `session_start`.
-- Best-effort fallback: corrupt/empty checkpoint → falls through to the normal fresh
-  path (no panic, `session_start` emitted).
+- **Truncation recovery:** truncate a checkpoint mid-array, assert `try_load_checkpoint`
+  recovers via `std/json.repair` (or cleanly returns `None` if unrecoverable — never
+  panics).
+- **Step-0 coverage:** drive `loop_v2` for a single step and assert the checkpoint
+  written at the top contains the initial `[system, user-task]` (proves an abort during
+  the first step still preserves the original task — the issue's exact scenario).
+- Resume entry: given a checkpoint on disk, `resume_v2_conversation` emits
+  `session_resume` with the right `restored_messages` count and enters
+  `conversation_loop_v2` with the restored history.
+- Best-effort fallback: missing/corrupt checkpoint → `resume_v2_conversation` falls back
+  to `msgs_to_messages(fallback_init)` (no panic, still emits `session_resume`).
 
 ### TS (`src/tui/src/…`)
 
@@ -361,11 +510,33 @@ before 3.
 
 ## Blast radius / rollback
 
+### At a glance
+
+| Patch | Files touched | Lines of change | Risk | Reversibility | Effect when feature off |
+|---|---|---|---|---|---|
+| 1 — stable session id | `src/tui/src/index.ts`, `src/tui/src/runtime-process.ts` | small (~1 var + 1 env entry) | Low | `git revert` clean | n/a — always on, but only adds an env var the runtime already prefers |
+| 2 — checkpoint writes | `src/core/agent_loop_v2.ail` (+ AILANG tests) | medium (codec + helper + **one** top-of-loop call site) | Low–Med | `git revert` clean | one best-effort per-step file write; never reads back |
+| 3 — resume + cleanup | `src/core/rpc.ail`, `src/core/agent_loop_v2.ail`, `src/tui/src/index.ts`, `src/tui/src/runtime-process.ts`, `src/tui/src/session-logger.ts` (+ tests) | medium | Med | `git revert` clean | gated on `MOTOKO_RESUME=1`; absent the flag, byte-for-byte the old path |
+
+**Scope guarantees.** No changes to streaming, tool dispatch, the JSONL event shape
+(only an additive `session_resume` event type), or the legacy `/abort` / Ctrl+C /
+`/restart` paths. Eval-harness runs are unaffected (they set `MOTOKO_SESSION_ID`
+themselves and never set `MOTOKO_RESUME`). New on-disk artifact is confined to the
+sandboxed `${workdir}/.motoko/session/` and removed on clean exit.
+
+**Worst-case failure mode.** A bug in the `Message`↔JSON codec (Patch 2) could yield a
+malformed *restored* history — bounded by: (a) the round-trip unit test, (b) resume
+being best-effort (corrupt/empty checkpoint → fresh path), and (c) the gate, so a
+non-aborted session is never affected beyond a per-step write.
+
+### Per-patch detail
+
 - Patch 1: one env var + one id variable. `git revert` clean.
-- Patch 2: new helpers + checkpoint calls at recursion points; if `messages_to_json`
-  drops a field the *restored* history could be malformed — covered by the round-trip
-  test, and resume is best-effort (corrupt → fresh). No effect on a session that never
-  aborts beyond a per-step file write.
+- Patch 2: new codec + a single checkpoint write at the top of `loop_v2` (covers all 7
+  recursion branches and step 0); if `message_to_json`/`json_to_messages` drops a field
+  the *restored* history could be malformed — covered by the round-trip test, and resume
+  is best-effort (corrupt → repair → fallback). No effect on a session that never aborts
+  beyond a per-step file write.
 - Patch 3: new resume branch in `run_with_config` + `resume_v2_conversation` wrapper +
   TS respawn flag + cleanup. The resume branch is gated on `MOTOKO_RESUME=1`, so absent
   the flag behavior is byte-for-byte the old path.

--- a/.agent/plans/steering_capability/Abort_Context_Persistence_Option_A.md
+++ b/.agent/plans/steering_capability/Abort_Context_Persistence_Option_A.md
@@ -1,0 +1,386 @@
+# Plan: Preserve context across ESC abort (Option A — checkpoint + rehydrate)
+
+Fixes GitHub issue **#15 — "Aborting (Esc) in the middle of a task flushes the
+context window."**
+
+## Background
+
+Pressing **ESC** mid-task wipes the conversation. Repro (from the issue): start a
+task, ESC ~55 s in, then ask "What was my last prompt?" → the agent answers it has
+no access to previous history. The follow-up runs with an empty context.
+
+### Root cause (traced end-to-end)
+
+The conversation history lives **only in the runtime process's memory**:
+
+- `loop_v2` carries it as the recursive parameter `msgs: [Message]`
+  (`src/core/agent_loop_v2.ail:1140+`).
+- Between turns, `conversation_loop_v2` holds it as `history: [Message]`
+  (`src/core/agent_loop_v2.ail:1490-1496`).
+
+ESC is wired to a **hard kill**, not a soft abort:
+
+- `src/tui/src/ui.ts:2140-2145` — ESC while a task runs calls `this.onInterrupt?.()`.
+- `src/tui/src/index.ts:958` — `onInterrupt = () => { interrupted = true; runtimeProcess?.kill(); }` → **SIGTERM**.
+- `src/tui/src/index.ts:932-935` — on process exit, the `interrupted` flag skips
+  `process.exit` and calls `ui.setAwaitingTask(true)`.
+- `src/tui/src/ui.ts:4000-4005` — the next plain submission routes through
+  `onInitialTask` → `spawnRuntimeProcess(value, true)` — a **brand-new process with
+  empty history**.
+
+SIGTERM destroys the in-memory `[Message]` list; the respawn starts fresh. Hence the
+flushed context.
+
+### Why not "just don't kill the process" (Option B is blocked)
+
+A soft abort that keeps the process alive would need the runtime to notice the abort
+**mid-task**. It can't:
+
+- `conversation_loop_v2` reads commands with a **blocking** `readLine()`
+  (`src/core/agent_loop_v2.ail:1517`); it only runs *between* turns, and its `abort`
+  handler returns `()` = **ends the session** (`:1523`).
+- `loop_v2` never polls stdin between steps.
+- Grounded against the AILANG docs MCP (CLI v0.24.2): **`std/io` exposes only**
+  `exit`, `print`, `println`, `readLine`, `writeBytes`. `readLine() -> string ! {IO}`
+  is the sole stdin primitive and it **blocks** — there is no non-blocking / poll /
+  `tryRead` / fd-select variant. The in-code comment at
+  `src/core/agent_loop_v2.ail:1510` confirms it ("readLine ... blocks on non-TTY
+  stdin instead of returning EOF").
+
+The legacy design (`.agent/plans/ESC_Interrupt.md`,
+`.agent/plans/Abort_History_And_Omnigraph_Delete.md`) relied on a non-blocking
+`check_abort()` poll in the old `src/core/rpc.ail` `rpc_loop`. That runtime is gone:
+`main()` now routes `run_with_config` → `run_v2_with_conversation`
+(`src/core/rpc.ail:156,237`), and the v2 rewrite dropped both the mid-step abort poll
+and the abort-history preservation. So #15 is a **regression** introduced by the v2
+cutover, and the original poll-based approach is not reproducible in pure AILANG today.
+
+Conclusion: while AILANG lacks a non-blocking stdin primitive, the **only** way to
+interrupt a blocking in-flight step is to kill the process. To survive that, the
+history must be **persisted to disk and rehydrated on respawn**.
+
+> A companion AILANG-side feedback item should request a non-blocking stdin / poll
+> primitive so the cleaner Option B (no process churn, preserves the partial in-flight
+> turn) becomes possible later. That is upstream work and out of scope for this plan.
+
+## Goals
+
+- After ESC, a follow-up prompt sees the full prior conversation (system + every
+  user/assistant/tool message up to the last completed step).
+- The fix works within current AILANG v0.24.2 — no upstream language change required.
+- No behavior change to normal completion, `/abort`, Ctrl+C, `/restart`, or model
+  switching.
+- The checkpoint is keyed to the session so concurrent/serial sessions don't collide,
+  and is cleaned up when a session ends normally.
+
+## Non-goals
+
+- Preserving the *partial* in-flight assistant turn (the one interrupted mid-stream).
+  We checkpoint at **step boundaries**, so the interrupted step's incomplete output is
+  not recovered. (Recovering it needs Option B / a non-blocking abort signal.)
+- Cross-restart history for `/restart` profile changes (separate `session_suspend`
+  path; can reuse the same checkpoint later but not in this plan).
+- Any change to streaming, tool dispatch, or the JSONL event protocol shape.
+- Multi-session history browsing / resume-by-id UX.
+
+---
+
+## Design overview
+
+Three coordinated changes:
+
+1. **Stable session id across respawn (TS).** The TUI generates one session id per
+   *logical* session and passes it via `MOTOKO_SESSION_ID` to both the original and the
+   ESC-respawned process. This id keys the checkpoint file. (Today
+   `MOTOKO_SESSION_ID` is only set by the eval adapter; interactive runs fall back to
+   `session_${now()}`, which differs per process — unusable as a stable key.)
+
+2. **Checkpoint after each step (AILANG).** `loop_v2` serializes its `[Message]`
+   history to `${workdir}/.motoko/session/<session_id>.json` after each step, and
+   `conversation_loop_v2` re-checkpoints after each completed turn. Writes are
+   atomic-ish (write temp + rename via two `std/fs` calls, or accept truncating
+   `writeFile` since a step boundary is a consistent point).
+
+3. **Resume on respawn (AILANG + TS).** When the TUI respawns after ESC, it sets
+   `MOTOKO_RESUME=1`. `run_with_config` checks for the checkpoint; if present and
+   resume is requested, it loads the persisted `[Message]` history and enters
+   `conversation_loop_v2` directly (waiting for the next `user_message`) instead of
+   running the fresh `init` task. The first post-ESC submission becomes a
+   `user_message` appended to the restored history.
+
+The checkpoint lives under `workdir` because the runtime's FS is sandboxed to
+`AILANG_FS_SANDBOX = workdir` (`src/tui/src/runtime-process.ts:308`). The TS-side JSONL
+log under `projectRoot/.motoko/logfile` is written by the TUI, not the sandboxed
+runtime, so it cannot be the runtime's checkpoint target.
+
+---
+
+## Patch 1 — Stable, shared session id (TS)
+
+**File:** `src/tui/src/index.ts`
+
+In the TTY path, generate one session id up front (before the first
+`spawnRuntimeProcess`) and reuse it for every respawn in the same logical session:
+
+```ts
+// One id per logical session; survives ESC respawns so the runtime checkpoint
+// key is stable. New value only on /restart (fresh session).
+let sessionId = `session_${new Date().toISOString().replace(/[:.]/g, "-")}`;
+```
+
+Thread it into `RuntimeProcess` so it is exported as `MOTOKO_SESSION_ID` in the child
+env (extend the env allowlist block at `src/tui/src/runtime-process.ts:300-330`):
+
+```ts
+MOTOKO_SESSION_ID: process.env.MOTOKO_SESSION_ID ?? this.sessionId,
+```
+
+This also makes `SessionLogger`'s filename stem (`session-logger.ts:233-237`) and the
+AILANG-side `derive_session_id()` (`agent_loop_v2.ail:255`) converge on the same id for
+interactive runs — today they diverge (ISO stem vs `session_${now()}`), which is a
+latent inconsistency this patch incidentally fixes.
+
+On `/restart`, mint a new `sessionId` (it's a genuinely new session).
+
+**Blast radius:** additive env var; the runtime already prefers an existing
+`MOTOKO_SESSION_ID`. No effect on eval-harness runs (they set it themselves).
+
+---
+
+## Patch 2 — Checkpoint history after each step (AILANG)
+
+**File:** `src/core/agent_loop_v2.ail`
+
+### 2a. Message ↔ JSON round-trip
+
+The file already serializes tool results (`tool_messages_to_result_jsons`,
+`:544`) and converts `[Msg]`↔`[Message]` (`msgs_to_messages` `:342`,
+`messages_to_msgs` `:468`). Add a faithful full-`Message` codec covering all four
+fields (`role`, `content`, `tool_calls`, `tool_call_id`):
+
+```ailang
+func message_to_json(m: Message) -> Json { ... }      -- includes tool_calls array
+func messages_to_json(ms: [Message]) -> Json { ja(map(message_to_json, ms)) }
+func json_to_message(j: Json) -> Message { ... }
+func json_to_messages(j: Json) -> [Message] { ... }   -- tolerant of missing fields
+```
+
+`tool_calls` must round-trip (id, name, arguments) — reuse whatever ToolCall JSON
+shape `step_result_to_message` / the hybrid path already build (`:1246-1251`) so the
+restored history is accepted by every provider (the Bedrock tool_use correlation note
+at `:1228-1245` applies — a restored assistant message with tool_calls must keep its
+`tool_call_id` correlation intact).
+
+### 2b. Checkpoint helper
+
+```ailang
+func checkpoint_path(workdir: string, session_id: string) -> string {
+  "${workdir}/.motoko/session/${session_id}.json"
+}
+
+func write_checkpoint(workdir: string, session_id: string, msgs: [Message]) -> () ! {FS} {
+  let _ = mkdirAllResult("${workdir}/.motoko/session");
+  let body = encode(jo([
+    kv("schema_version", jnum(1.0)),
+    kv("session_id", js(session_id)),
+    kv("messages", messages_to_json(msgs))
+  ]));
+  -- writeFileResult so a checkpoint failure never aborts the task.
+  let _ = writeFileResult(checkpoint_path(workdir, session_id), body);
+  ()
+}
+```
+
+Use the `Result` variants (`writeFileResult`, `mkdirAllResult`) so a disk error
+degrades to "no checkpoint" rather than killing the run.
+
+### 2c. Call sites
+
+- In `loop_v2`, after each step's history is finalized and **before** the recursive
+  call (every branch that recurses with `next_msgs` — e.g. `:1211`, `:1255`, and the
+  typed-tool-calls dispatch branch), call
+  `write_checkpoint(workdir, session_id, next_msgs)`. Centralize by writing once at the
+  point `next_msgs` is computed, or wrap the recursion in a small helper that
+  checkpoints then recurses.
+- In `conversation_loop_v2`, after a turn returns `Ok(updated_history)` (`:1553`),
+  `write_checkpoint(workdir, session_id, updated_history)` before recursing.
+
+`loop_v2` and `conversation_loop_v2` already declare the `FS` effect, so no signature
+changes. `workdir` and `session_id` are already in scope in both.
+
+**Frequency / cost:** one truncating write per step of the full message list. For
+typical step counts and message sizes this is negligible; if it ever matters, switch to
+append-only JSONL deltas. Not needed now.
+
+---
+
+## Patch 3 — Resume from checkpoint on respawn (AILANG + TS)
+
+### 3a. TS — request resume on ESC respawn
+
+**File:** `src/tui/src/index.ts`
+
+The interrupted-respawn path is the `setAwaitingTask(true)` branch at `:932-935`. The
+next submission currently calls `onInitialTask → spawnRuntimeProcess(value, true)`.
+Change the respawn after an interrupt to pass a resume flag so the new process
+rehydrates instead of starting the task fresh:
+
+- Set `MOTOKO_RESUME=1` in the child env for respawns that follow an interrupt
+  (thread a `resume: boolean` through `spawnRuntimeProcess` / `RuntimeProcess`, exported
+  alongside `MOTOKO_SESSION_ID` in `runtime-process.ts`).
+- The post-ESC first submission should be delivered as a **`user_message`** on the
+  resumed session, not as the initial `task`. Concretely: after an interrupt, the
+  respawn happens immediately (empty task) with `MOTOKO_RESUME=1`; the runtime
+  rehydrates and enters `conversation_loop_v2` waiting on stdin; the user's next line is
+  sent via `runtimeProcess.sendUserMessage(...)` (the `taskDone`/follow-up path,
+  `ui.ts:4009-4017`), exactly like a normal follow-up after `done`.
+
+  This means after ESC the UI should transition to the **follow-up** state
+  (`taskDone = true`) rather than the **awaiting-initial-task** state, so plain text
+  routes to `onUserMessage` not `onInitialTask`. Adjust the interrupt branch at
+  `index.ts:932-935` accordingly (e.g. respawn with resume immediately, then
+  `ui.setTaskDone(true)` once the resumed process signals it is ready).
+
+### 3b. AILANG — load checkpoint and enter the conversation loop
+
+**File:** `src/core/rpc.ail` (`run_with_config`, `:156-238`)
+
+Before building the fresh `init` task, check for resume:
+
+```ailang
+let resume = getEnvOr("MOTOKO_RESUME", "") == "1";
+let session_id = getEnvOr("MOTOKO_SESSION_ID", "");
+let ckpt = "${cwd}/.motoko/session/${session_id}.json";
+```
+
+If `resume && session_id != "" && fileExists(ckpt)`:
+
+- Read + decode the checkpoint, `json_to_messages` → restored `[Message]`.
+- Emit a `session_resume` event (new event type; mirror `session_start` fields plus
+  `restored_messages: <count>`) so the TUI/logger can show "resumed N messages".
+- Call a new exported entry `resume_v2_conversation(rt, env_url, ..., restored_history,
+  ...)` that **skips the initial run** and goes straight to `conversation_loop_v2` with
+  the restored history. This reuses the existing `conversation_loop_v2` verbatim.
+- On decode failure or empty/missing checkpoint, **fall through** to the normal fresh
+  `init` path (resume is best-effort, never fatal).
+
+Otherwise: the existing `run_v2_with_conversation(... init ...)` path, unchanged.
+
+Add the `resume_v2_conversation` wrapper next to `run_v2_with_conversation`
+(`agent_loop_v2.ail:1576`) — it is `run_v2_with_conversation` minus the initial
+`run_v2_from_messages` call:
+
+```ailang
+export func resume_v2_conversation(
+  rt, env_url, hybrid_tools, budget, model,
+  restored_history: [Message], workdir, step_budget, ohmy_pi,
+  max_cost_millicents, cost_rates, provider, session_id
+) -> () ! {AI, FS, Process, IO, Env, Net, SharedMem, Clock, Stream, Trace} {
+  conversation_loop_v2(rt, env_url, hybrid_tools, budget, model,
+    restored_history, workdir, step_budget, ohmy_pi,
+    max_cost_millicents, cost_rates, provider, session_id)
+}
+```
+
+Note: pass `session_id` explicitly (don't re-`derive_session_id()`) so the checkpoint
+key stays stable across the resumed turns.
+
+### 3c. Normal-exit cleanup
+
+When a session ends normally (the non-interrupted exit at `index.ts:941-946`, after
+`done`), delete the checkpoint so a later unrelated session with a recycled id can't
+resume stale history. Either:
+
+- TS: `fs.rm` the `${workdir}/.motoko/session/${sessionId}.json` on clean exit; or
+- AILANG: `removeFileResult(checkpoint_path(...))` when `conversation_loop_v2` reads an
+  `exit`/`abort` command (`:1523`) and is genuinely ending.
+
+TS-side cleanup is simpler and keeps the AILANG abort handler untouched. Prefer TS.
+
+---
+
+## Event protocol additions
+
+- New event `session_resume` (AILANG → TUI): `{ type, session_id, model,
+  restored_messages }`. The TUI shows "Resumed N messages" in history; the
+  SessionLogger logs it. Add the type to the `AgentEvent` union in
+  `src/tui/src/runtime-process.ts` and a transcript line in
+  `src/tui/src/session-logger.ts`.
+
+No other protocol changes.
+
+---
+
+## Tests
+
+### AILANG (`src/core/test/…`)
+
+- `message_to_json` / `json_to_messages` round-trip: a `[Message]` containing a system
+  msg, a user msg, an assistant msg **with tool_calls**, and a tool-role msg with a
+  `tool_call_id` survives encode→decode unchanged (field-by-field).
+- `write_checkpoint` then read-back: assert the file at `checkpoint_path` decodes to the
+  same messages.
+- Resume entry: given a checkpoint on disk and `MOTOKO_RESUME=1` +
+  `MOTOKO_SESSION_ID`, `run_with_config` enters the resume path (assert a
+  `session_resume` event is emitted with the right `restored_messages` count) and does
+  **not** emit a fresh-task `session_start`.
+- Best-effort fallback: corrupt/empty checkpoint → falls through to the normal fresh
+  path (no panic, `session_start` emitted).
+
+### TS (`src/tui/src/…`)
+
+- `runtime-process` env: `MOTOKO_SESSION_ID` is exported and stable across a respawn;
+  `MOTOKO_RESUME=1` is set only on the post-interrupt respawn.
+- Stream-protocol scenario (extends the pattern in
+  `runtime-process.stream-protocol.test.ts`): user_message → `tool_calls` event → ESC
+  (kill) → respawn with resume → send a second user_message → assert the next
+  `thinking` event's input contains the **first** prompt's content (history restored).
+- UI: after an interrupt+resume, plain text routes to `onUserMessage` (follow-up), not
+  `onInitialTask`.
+
+### Manual reproduction (the issue scenario)
+
+`make run`, start "Read README.md and run ailang prompt", ESC mid-task, then ask
+"What was my last prompt?" → the agent references the README task. Confirm
+`${workdir}/.motoko/session/<id>.json` exists during the run and is gone after a clean
+exit.
+
+---
+
+## Order of work
+
+1. **Patch 1** (stable session id) — prerequisite for any checkpoint keying. Independent,
+   low risk, also fixes the latent triple-session-id divergence.
+2. **Patch 2** (checkpoint writes) — additive; with Patch 1 the file appears on disk but
+   nothing reads it yet. Verifiable in isolation (inspect the file).
+3. **Patch 3** (resume) — wires read-back + TS respawn flag + cleanup. The user-visible
+   fix lands here.
+
+Each patch is independently testable and revertible. Patches 1–2 are safe to land
+before 3.
+
+## Blast radius / rollback
+
+- Patch 1: one env var + one id variable. `git revert` clean.
+- Patch 2: new helpers + checkpoint calls at recursion points; if `messages_to_json`
+  drops a field the *restored* history could be malformed — covered by the round-trip
+  test, and resume is best-effort (corrupt → fresh). No effect on a session that never
+  aborts beyond a per-step file write.
+- Patch 3: new resume branch in `run_with_config` + `resume_v2_conversation` wrapper +
+  TS respawn flag + cleanup. The resume branch is gated on `MOTOKO_RESUME=1`, so absent
+  the flag behavior is byte-for-byte the old path.
+
+## How we'll know it worked
+
+- The issue repro (task → ESC → "what was my last prompt?") returns the prior task.
+- `session_resume` events appear in the JSONL log with a non-zero `restored_messages`.
+- Normal completion leaves no `.motoko/session/<id>.json` behind.
+- `make check_core` + `make test` + `cd src/tui && bun run test` green.
+
+## Follow-up (separate, upstream)
+
+File AILANG-side feedback (via the `ailang-feedback` skill) requesting a **non-blocking
+stdin read / poll** primitive in `std/io`. With that, Option B becomes viable: ESC
+sends a soft abort, `loop_v2` polls between steps, returns its `[Message]` to
+`conversation_loop_v2`, and the process stays alive — preserving even the partial
+in-flight turn and removing the kill/respawn churn this plan works around.

--- a/.agent/plans/steering_capability/HANDOFF_Abort_Context_Persistence.md
+++ b/.agent/plans/steering_capability/HANDOFF_Abort_Context_Persistence.md
@@ -1,0 +1,105 @@
+# Handoff: implement "Preserve context across ESC abort (Option A)"
+
+You are implementing the plan in
+[`Abort_Context_Persistence_Option_A.md`](./Abort_Context_Persistence_Option_A.md)
+(same directory). Read it in full before writing any code — it is the source of truth;
+this file is the operating brief around it.
+
+## What you're fixing
+
+GitHub issue **#15**: pressing **ESC** mid-task SIGTERM-kills the AILANG runtime, which
+holds the conversation history only in memory (`loop_v2`'s `[Message]` param), so the
+next prompt respawns a fresh, empty process and the agent loses all context. The fix
+persists history to disk on a step boundary and rehydrates it on the post-ESC respawn.
+
+## Scope — three patches, land in order
+
+1. **Patch 1 — stable session id (TS).** `src/tui/src/index.ts`,
+   `src/tui/src/runtime-process.ts`. Prerequisite for 2 and 3.
+2. **Patch 2 — checkpoint writes (AILANG).** `src/core/agent_loop_v2.ail`. One
+   checkpoint at the **top of `loop_v2`** (≈`:1075`) + secondary in
+   `conversation_loop_v2` after `Ok(updated_history)`. Plus the `Message`↔JSON codec.
+3. **Patch 3 — resume (AILANG + TS).** `src/core/rpc.ail`, `src/core/agent_loop_v2.ail`,
+   `src/tui/src/index.ts`, `src/tui/src/runtime-process.ts`,
+   `src/tui/src/session-logger.ts`. The user-visible fix lands here.
+
+Each patch is independently testable and revertible; commit them separately. Do **not**
+fold them into one commit.
+
+## Hard constraints
+
+- **Phoenix Architecture / no human-written code.** You (the agent) write all code. Match
+  the surrounding style: explicit recursion over `map`+lambda (there is a known
+  match-in-lambda parser bug, see `agent_loop_v2.ail:1125`); reuse existing helpers
+  (`msg_get_str`, `msgs_to_messages`, `emit_event`, `_int_to_float`) rather than
+  inventing new ones.
+- **Ground every AILANG stdlib assumption against the AILANG docs MCP** (`ailang-docs`,
+  defined in `.mcp.json`) for the installed version (`ailang version` → query the MCP's
+  "latest"). The plan already verified: `std/io` is blocking-only (no non-blocking
+  stdin — that's why Option B is deferred), `std/fs` has `writeFile`/`writeFileResult`/
+  `readFileResult`/`mkdirAllResult`/`fileExists`/`removeFile` but **no `rename`**, and
+  `std/json` has `getArray`/`getString`/`asArray`/`repair`. If you reach for any other
+  stdlib function, confirm it exists via the MCP first — do not assume.
+- **Keep `rpc.ail` codec-free.** It must not import `Message`. All `Message`/JSON logic
+  lives in `agent_loop_v2.ail` behind `try_load_checkpoint` / `resume_v2_conversation`.
+- **Resume is best-effort, never fatal.** Missing/corrupt checkpoint → `repair` retry →
+  fall back to the init history. A checkpoint write failure must never abort a task (use
+  the `*Result` fs variants and discard the error).
+- **The checkpoint key depends on Patch 1.** `loop_v2` and `conversation_loop_v2` derive
+  `session_id` independently; they only agree when `MOTOKO_SESSION_ID` is set. Verify
+  Patch 1 actually exports that env var to the child before testing Patch 2.
+
+## Watch-outs (real traps, already analysed)
+
+- `loop_v2` recurses from **7** branches (`:1211,:1255,:1283,:1299,:1322,:1338,:1374`).
+  Do **not** checkpoint per-branch — the single top-of-loop site covers all of them plus
+  step 0. If you find yourself editing 7 sites, stop and re-read Patch 2c.
+- `ToolCall.arguments` is a **JSON-encoded string** (`std/ai`), not a `Json`. Do not
+  confuse it with `tool_contract.ToolCallEnvelope.arguments` (which is a `Json`).
+- The respawn-with-resume path replaces the current `setAwaitingTask(true)` interrupt
+  branch (`index.ts:932-935`). After resume, plain input must route to `onUserMessage`
+  (follow-up), **not** `onInitialTask` (fresh task). Drive that via the `session_resume`
+  event handler in the UI, since `taskDone` has no public setter.
+- `session_start` and `session_resume` must be **mutually exclusive** for one spawn —
+  gate the existing unconditional `session_start` emit in `rpc.ail` (~`:180-191`).
+- The FS sandbox is `AILANG_FS_SANDBOX = workdir` (`runtime-process.ts:308`). Write the
+  checkpoint under that same `workdir` (= `cwd` in `run_with_config`). The TS-side
+  cleanup must target the identical path.
+
+## Validation (must all pass before calling it done)
+
+- `make check_core` — type-checks all `.ail` modules.
+- `make test` — core runtime tests (add the AILANG tests from the plan's Tests section:
+  codec round-trip, truncation/`repair` recovery, step-0 coverage, resume entry,
+  best-effort fallback).
+- `cd src/tui && bun run test` — add the TS tests: env (`MOTOKO_SESSION_ID` stable +
+  `MOTOKO_RESUME` only on interrupt respawn), the stream-protocol resume scenario, and
+  the UI follow-up-routing test.
+- **Manual repro of #15** (the acceptance test): `make run`, start "Read README.md and
+  run ailang prompt", press ESC mid-task, then ask "What was my last prompt?" → the agent
+  must reference the README task. Confirm `${workdir}/.motoko/session/<id>.json` exists
+  during the run and is removed after a clean exit. Use the `run` or `verify` skill to
+  drive this.
+
+## Definition of done
+
+All four validation gates green, three commits (one per patch) on a feature branch (not
+`main`), and a PR description that links issue #15 and the plan file. Do **not** push or
+open the PR until the user asks.
+
+## Out of scope (do not attempt here)
+
+- Non-blocking stdin / soft-abort (Option B) — blocked on an upstream AILANG primitive.
+  After this lands, file that as AILANG feedback via the `ailang-feedback` skill; don't
+  implement it in this repo.
+- Recovering the *partial* in-flight (interrupted) step's output — explicit non-goal; the
+  checkpoint is the pre-step snapshot.
+- `/restart` cross-session history, multi-session resume UX.
+
+## If you get stuck
+
+- AILANG compiler/parser/stdlib error whose symptom is in `ailang check`/`ailang run`
+  output → it's likely an AILANG-side issue; route via the `ailang-feedback` skill rather
+  than working around it silently.
+- Plan assumption contradicted by the code → stop, report the contradiction, and propose
+  the adjustment before proceeding. Don't paper over it.

--- a/.agent/plans/steering_capability/Persistent_Session_Resume_Followup.md
+++ b/.agent/plans/steering_capability/Persistent_Session_Resume_Followup.md
@@ -1,0 +1,63 @@
+# Follow-up: Durable Session Resume
+
+## Context
+
+Option A for issue #15 added a transient checkpoint at
+`${workdir}/.motoko/session/<session_id>.json` so an interactive TUI session can
+survive an ESC hard-kill and immediately respawn with context. That checkpoint is
+deleted on clean exit or restart by design.
+
+This note tracks a possible separate feature: allowing a later agent or a new TUI
+process to explicitly resume a prior session.
+
+## Why This Is Separate From ESC Recovery
+
+The ESC checkpoint is crash-recovery state, not a durable session store:
+
+- It contains raw model history, including tool calls, tool results, paths, command
+  output, and possibly sensitive data.
+- It is keyed by an internal `MOTOKO_SESSION_ID`, not a user-facing resume id.
+- It has no retention policy, index, migration story, ownership checks, or selection
+  UX.
+- It is a step-boundary snapshot, so it may intentionally omit the interrupted
+  in-flight step's partial output.
+- Automatically reusing stale checkpoints risks leaking old context into unrelated
+  future work.
+
+## Candidate Design
+
+Implement persistent resume as an explicit workflow, not by keeping transient ESC
+checkpoints indefinitely.
+
+Possible shape:
+
+- Add a durable session store under `.motoko/sessions/` or extend the existing
+  `.motoko/logfile/` JSONL transcript system with a resumable metadata index.
+- Store metadata per session: id, created/updated timestamps, workdir, profile,
+  model, first prompt, last prompt, status, schema version, and checkpoint path.
+- Add explicit UX: `/sessions`, `/resume <id>`, maybe `/save-session` or a config
+  option controlling automatic retention.
+- Keep resume opt-in. A fresh agent must never inherit a prior session only because
+  a checkpoint file exists.
+- Add retention and privacy controls: max age/count, manual delete, and clear
+  labeling that tool outputs and file paths may be stored.
+- Prefer reconstructing from a durable transcript or a dedicated validated history
+  store rather than treating the transient `.motoko/session/<id>.json` file as the
+  public API.
+
+## Open Questions
+
+- Should persistent resume preserve the full typed `[Message]` history, a compacted
+  summary, or both?
+- Should `/restart` become resumable across profiles, or should profile changes
+  always start a new logical session?
+- What should happen when extension/tool schemas changed since the saved session?
+- Should saved sessions be portable across machines or strictly local to a workdir?
+
+## Acceptance Sketch
+
+- A user can list previous sessions with enough metadata to choose the right one.
+- A user can explicitly resume one session and ask a follow-up that sees prior
+  context.
+- A new unrelated session does not load stale context accidentally.
+- Sensitive session data can be deleted predictably.

--- a/.agent/prs/mot-17-preserve-context-across-esc-abort.md
+++ b/.agent/prs/mot-17-preserve-context-across-esc-abort.md
@@ -1,0 +1,111 @@
+# Preserve context across ESC abort
+
+Fixes #15
+
+## Summary
+
+This PR implements the Option A checkpoint/rehydrate path from
+`.agent/plans/steering_capability/Abort_Context_Persistence_Option_A.md`.
+
+Pressing ESC currently hard-kills the AILANG runtime. Because the v2 conversation
+history lives in process memory, the next prompt starts from an empty context. This
+change makes ESC recovery explicit:
+
+- The TUI creates and reuses one stable `MOTOKO_SESSION_ID` for a logical session.
+- The AILANG v2 loop checkpoints typed `[Message]` history to
+  `.motoko/session/<session_id>.json` at step boundaries.
+- After ESC, the TUI respawns the runtime with `MOTOKO_RESUME=1`.
+- The runtime loads the checkpoint best-effort and emits `session_resume`.
+- The UI treats the next plain input as a follow-up message, not a fresh task.
+- Clean exits and restarts remove the transient checkpoint.
+
+The checkpoint is intentionally transient crash-recovery state, not a durable session
+store. A separate follow-up note captures a possible explicit persistent resume feature.
+
+## What Changed
+
+### TUI runtime lifecycle
+
+- Added stable interactive session id generation and forwarding via
+  `MOTOKO_SESSION_ID`.
+- Added a resume flag through `spawnRuntimeProcess` / `RuntimeProcess`, exported as
+  `MOTOKO_RESUME=1` only for the post-ESC respawn.
+- On ESC runtime exit, respawn immediately into resume mode instead of calling
+  `setAwaitingTask(true)`.
+- Delete the transient checkpoint on clean exit and `/restart`.
+- Ignore repeated ESC key events while the first interrupt is still pending, preventing
+  duplicate `Task interrupted` lines.
+
+### AILANG checkpoint and resume
+
+- Added a `Message`/`ToolCall` JSON codec inside `agent_loop_v2.ail`.
+- Added best-effort checkpoint writes using `mkdirAllResult` and `writeFileResult`.
+- Added checkpoint loading with `readFileResult`, `std/json.repair` retry, and fallback
+  to init history on missing/corrupt checkpoints.
+- Added `resume_v2_conversation` and `session_resume` event emission.
+- Gated `rpc.ail` so `session_start` and `session_resume` are mutually exclusive for a
+  spawn.
+- Kept `rpc.ail` codec-free; typed message/JSON logic stays in `agent_loop_v2.ail`.
+
+### UI and logging
+
+- Added `session_resume` to the TUI event protocol.
+- Added UI handling that sets the run state to idle and enables follow-up routing.
+- Added transcript logging for resumed sessions.
+- Added a pure input-routing helper and regression coverage for the follow-up route.
+
+### Tests and docs
+
+- Added AILANG codec and repair-recovery tests.
+- Added TUI env tests for `MOTOKO_SESSION_ID` and `MOTOKO_RESUME`.
+- Added stream-protocol coverage for `session_resume`.
+- Added UI routing coverage for post-resume follow-up input.
+- Updated the TUI test script to run Jest under Node with ESM support via
+  `bun run test`.
+- Added plan and handoff docs under `.agent/plans/steering_capability/`.
+- Added `Persistent_Session_Resume_Followup.md` for a future durable session resume
+  feature.
+
+### Other branch changes
+
+- `.gitignore` now ignores `.motoko/session`.
+- A few example AILANG files switch string concatenation sites to `concat([...])`.
+
+## Validation
+
+Automated validation run during implementation:
+
+- `make check_core`
+- `make test`
+- `cd src/tui && bun run build`
+- `cd src/tui && bun run test`
+- Focused AILANG test: `ailang test src/core/agent_loop_v2.ail`
+- Noninteractive resume smoke: pre-created `.motoko/session/<id>.json`, launched with
+  `MOTOKO_RESUME=1`, and confirmed `session_resume` emitted with restored messages and
+  no startup `session_start` event.
+
+Note: `bun run test` prints an existing `test/path-guard.test.ts` diagnostic about
+`process.exit(0)`, but exits successfully.
+
+## Manual Acceptance Scenario
+
+Expected behavior after this PR:
+
+1. Start `make run`.
+2. Ask: `Read README.md and run ailang prompt`.
+3. Press ESC mid-task.
+4. Ask: `What was my last prompt?`.
+5. The resumed agent should reference the README task instead of reporting no prior
+   context.
+
+During the interrupted run, `.motoko/session/<id>.json` should exist. After clean exit,
+the checkpoint should be removed.
+
+## Risk Notes
+
+- The checkpoint is a pre-step snapshot, so it does not preserve partial output from the
+  interrupted in-flight step.
+- Checkpoint writes are best-effort and must not abort a task.
+- Corrupt/truncated checkpoint reads fall back through `json.repair`, then to init
+  history if unrecoverable.
+- Durable cross-session resume is explicitly out of scope for this PR.

--- a/.agent/summaries/2026-06-21-esc-abort-context-persistence.md
+++ b/.agent/summaries/2026-06-21-esc-abort-context-persistence.md
@@ -1,0 +1,109 @@
+# ESC Abort Context Persistence Session
+
+## Goal
+
+Implement the plan in
+`.agent/plans/steering_capability/Abort_Context_Persistence_Option_A.md` to fix issue
+#15: pressing ESC mid-task killed the AILANG runtime and lost the in-memory v2
+conversation history.
+
+## Implemented
+
+Landed Option A as separate commits on
+`arniwesth/mot-17-reenable-gracefull-esc-steering-capability`:
+
+- `9933457 tui: pass stable session id to runtime`
+- `a370275 core: checkpoint v2 conversation history`
+- `39f992d agent: resume v2 conversation after interrupt`
+- `b9ea6c1 tui: ignore repeated escape interrupts`
+
+Additional branch commits after implementation:
+
+- `fa60b9e Added note on future improvements`
+- `b7e3710 Implemented plan`
+
+## Technical Summary
+
+### Stable session id
+
+- TUI now creates one logical `sessionId` for interactive runs.
+- `RuntimeProcess` forwards `MOTOKO_SESSION_ID` to the AILANG child.
+- `/restart` mints a new logical session id.
+
+### Checkpoint writes
+
+- `agent_loop_v2.ail` now has a `Message`/`ToolCall` JSON codec.
+- The v2 loop writes `.motoko/session/<session_id>.json` at the top of `loop_v2`,
+  covering step 0 and all recursive branches.
+- `conversation_loop_v2` also checkpoints after a successful completed follow-up turn.
+- Writes use `mkdirAllResult` and `writeFileResult`, so checkpoint failures do not abort
+  the task.
+
+### Resume after ESC
+
+- ESC sets an interrupt flag and hard-kills the runtime as before.
+- The TUI respawns immediately with `MOTOKO_RESUME=1` instead of asking for a fresh
+  initial task.
+- `rpc.ail` gates `session_start` so resume spawns emit only `session_resume`.
+- `agent_loop_v2.ail` loads checkpoints best-effort using `readFileResult`, retries
+  truncated/corrupt JSON via `std/json.repair`, and falls back to init history if
+  unrecoverable.
+- The UI handles `session_resume` by moving to idle/follow-up state, so the next plain
+  input routes through `onUserMessage` rather than `onInitialTask`.
+- Checkpoints are removed on clean exit and restart.
+
+### Duplicate ESC line fix
+
+- Repeated ESC key events before runtime exit could append `Task interrupted` twice.
+- Added an `interruptPending` guard in `AgentUI`.
+- The guard resets on `session_start`, `session_resume`, `done`, `error`, and when the
+  UI is set to await a new task.
+
+## Tests And Validation
+
+Automated validation run during implementation:
+
+- `make check_core`
+- `make test`
+- `cd src/tui && bun run build`
+- `cd src/tui && bun run test`
+- `ailang test src/core/agent_loop_v2.ail`
+- Focused TUI tests for runtime env, stream protocol resume events, and follow-up
+  routing.
+- Noninteractive smoke: pre-created `.motoko/session/<id>.json`, launched with
+  `MOTOKO_RESUME=1`, confirmed `session_resume` emitted with restored messages and no
+  startup `session_start`.
+
+Notes:
+
+- `bun run test` now runs Jest via Node with `--experimental-vm-modules --runInBand`.
+- The TUI suite exits successfully but still prints an existing diagnostic from
+  `test/path-guard.test.ts` because that helper calls `process.exit(0)`.
+
+## Documentation Added
+
+- `.agent/plans/steering_capability/Abort_Context_Persistence_Option_A.md`
+- `.agent/plans/steering_capability/HANDOFF_Abort_Context_Persistence.md`
+- `.agent/plans/steering_capability/Persistent_Session_Resume_Followup.md`
+- `.agent/prs/mot-17-preserve-context-across-esc-abort.md`
+
+The persistent resume follow-up note explains why the current checkpoint remains
+transient crash-recovery state and sketches an explicit future `/sessions` /
+`/resume <id>` style feature.
+
+## Current State
+
+- Branch is ahead of `origin/arniwesth/mot-17-reenable-gracefull-esc-steering-capability`
+  with the implementation commits.
+- `.agent/prs/mot-17-preserve-context-across-esc-abort.md` is currently untracked.
+- `oh-my-pi/` remains an unrelated untracked directory that was intentionally left
+  untouched.
+
+## PR Description
+
+The PR description was written to:
+
+`.agent/prs/mot-17-preserve-context-across-esc-abort.md`
+
+It summarizes the branch against `origin/main`, links issue #15, lists validation, and
+captures risk notes.

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ tmp/*
 eval_results/*
 logs/*
 .motoko/logfile/
+.motoko/session
 polyglot_logs/
 benchmark_generared_files/
 benchmarks/results/

--- a/src/core/agent_loop_v2.ail
+++ b/src/core/agent_loop_v2.ail
@@ -38,13 +38,13 @@ import std/ai (step, Message, ToolCall, ToolSchema, StepResult, AIError, StreamC
 import std/io (println, readLine)
 import std/clock (now)
 import std/env (getEnvOr)
-import std/json (Json, jo, ja, kv, js, jnum, jb, encode, decode, get, asString, getArray)
+import std/json (Json, jo, ja, kv, js, jnum, jb, encode, decode, repair, get, asString, getArray)
 import std/list as List (length)
 import std/result (Result, Ok, Err)
 import std/string (trim, startsWith, substring, toLower, contains)
 import std/string as Str (length)
 import std/process (exec, ProcessError, ProcessOutput)
-import std/fs (mkdirAllResult, writeFileResult)
+import std/fs (mkdirAllResult, writeFileResult, readFileResult)
 import std/bytes (toString)
 import std/trace as Trace
 import src/core/tool_catalog (tools_with_extensions)
@@ -443,6 +443,26 @@ func write_checkpoint(workdir: string, session_id: string, msgs: [Message]) -> (
   ()
 }
 
+func decode_checkpoint_body(body: string) -> Option[[Message]] {
+  match decode(body) {
+    Ok(j) => Some(json_to_messages(j)),
+    Err(_) => match repair(body) {
+      Ok(repaired) => match decode(repaired) {
+        Ok(j2) => Some(json_to_messages(j2)),
+        Err(_) => None
+      },
+      Err(_) => None
+    }
+  }
+}
+
+export func try_load_checkpoint(workdir: string, session_id: string) -> Option[[Message]] ! {FS} {
+  match readFileResult(checkpoint_path(workdir, session_id)) {
+    Ok(body) => decode_checkpoint_body(body),
+    Err(_) => None
+  }
+}
+
 func tool_call_eq(a: ToolCall, b: ToolCall) -> bool {
   a.id == b.id && a.name == b.name && a.arguments == b.arguments
 }
@@ -490,6 +510,27 @@ pure func test_checkpoint_message_codec_preserves_tool_calls() -> bool
     ];
     let encoded = jo([kv("messages", ja(messages_to_json(history)))]);
     messages_eq(json_to_messages(encoded), history)
+  }
+
+pure func test_checkpoint_decode_repair_recovers_truncated_body() -> bool
+  tests [((), true)]
+  {
+    let body = "{\"schema_version\":1,\"session_id\":\"s\",\"messages\":[{\"role\":\"user\",\"content\":\"hello\",\"tool_calls\":[],\"tool_call_id\":\"\"}";
+    match decode_checkpoint_body(body) {
+      Some(history) => messages_eq(history, [
+        { role: "user", content: "hello", tool_calls: [], tool_call_id: "" }
+      ]),
+      None => false
+    }
+  }
+
+pure func test_checkpoint_decode_corrupt_body_is_none() -> bool
+  tests [((), true)]
+  {
+    match decode_checkpoint_body("not json") {
+      Some(_) => false,
+      None => true
+    }
   }
 
 -- Build a [Message] entry for one assistant turn from the StepResult. Carries
@@ -1746,6 +1787,32 @@ export func run_v2_with_conversation(
       conversation_loop_v2(rt, env_url, hybrid_tools, budget, model, initial_messages, workdir, step_budget, ohmy_pi, max_cost_millicents, cost_rates, provider, session_id)
     }
   }
+}
+
+export func resume_v2_conversation(
+  rt: ExtRuntime,
+  env_url: string,
+  hybrid_tools: bool,
+  budget: BudgetPlan,
+  model: string,
+  fallback_init: [Msg],
+  workdir: string,
+  step_budget: int,
+  ohmy_pi: bool,
+  max_cost_millicents: int,
+  cost_rates: CostRates,
+  provider: StepProvider,
+  session_id: string
+) -> () ! {AI, FS, Process, IO, Env, Net, SharedMem, Clock, Stream, Trace} {
+  let history = match try_load_checkpoint(workdir, session_id) {
+    Some(restored) => restored,
+    None => msgs_to_messages(fallback_init)
+  };
+  let _ = emit_event(session_id, "session_resume", [
+    kv("model", js(model)),
+    kv("restored_messages", jnum(_int_to_float(List.length(history))))
+  ]);
+  conversation_loop_v2(rt, env_url, hybrid_tools, budget, model, history, workdir, step_budget, ohmy_pi, max_cost_millicents, cost_rates, provider, session_id)
 }
 
 -- Run loop_v2 with a scripted provider. No real LLM call made.

--- a/src/core/agent_loop_v2.ail
+++ b/src/core/agent_loop_v2.ail
@@ -38,12 +38,13 @@ import std/ai (step, Message, ToolCall, ToolSchema, StepResult, AIError, StreamC
 import std/io (println, readLine)
 import std/clock (now)
 import std/env (getEnvOr)
-import std/json (Json, jo, ja, kv, js, jnum, jb, encode, decode, get, asString)
+import std/json (Json, jo, ja, kv, js, jnum, jb, encode, decode, get, asString, getArray)
 import std/list as List (length)
 import std/result (Result, Ok, Err)
 import std/string (trim, startsWith, substring, toLower, contains)
 import std/string as Str (length)
 import std/process (exec, ProcessError, ProcessOutput)
+import std/fs (mkdirAllResult, writeFileResult)
 import std/bytes (toString)
 import std/trace as Trace
 import src/core/tool_catalog (tools_with_extensions)
@@ -350,6 +351,146 @@ func msgs_to_messages(msgs: [Msg]) -> [Message] {
     } :: msgs_to_messages(rest))
   }
 }
+
+func tool_call_to_json(tc: ToolCall) -> Json {
+  jo([
+    kv("id", js(tc.id)),
+    kv("name", js(tc.name)),
+    kv("arguments", js(tc.arguments))
+  ])
+}
+
+func tool_calls_to_json(tcs: [ToolCall]) -> [Json] {
+  match tcs {
+    [] => [],
+    tc :: rest => tool_call_to_json(tc) :: tool_calls_to_json(rest)
+  }
+}
+
+func message_to_json(m: Message) -> Json {
+  jo([
+    kv("role", js(m.role)),
+    kv("content", js(m.content)),
+    kv("tool_calls", ja(tool_calls_to_json(m.tool_calls))),
+    kv("tool_call_id", js(m.tool_call_id))
+  ])
+}
+
+func messages_to_json(ms: [Message]) -> [Json] {
+  match ms {
+    [] => [],
+    m :: rest => message_to_json(m) :: messages_to_json(rest)
+  }
+}
+
+func json_to_tool_call(j: Json) -> ToolCall {
+  {
+    id: msg_get_str(j, "id"),
+    name: msg_get_str(j, "name"),
+    arguments: msg_get_str(j, "arguments")
+  }
+}
+
+func json_to_tool_calls(items: [Json]) -> [ToolCall] {
+  match items {
+    [] => [],
+    j :: rest => json_to_tool_call(j) :: json_to_tool_calls(rest)
+  }
+}
+
+func json_to_message(j: Json) -> Message {
+  {
+    role: msg_get_str(j, "role"),
+    content: msg_get_str(j, "content"),
+    tool_calls: match getArray(j, "tool_calls") {
+      Some(tcs) => json_to_tool_calls(tcs),
+      None => []
+    },
+    tool_call_id: msg_get_str(j, "tool_call_id")
+  }
+}
+
+func json_to_message_list(items: [Json]) -> [Message] {
+  match items {
+    [] => [],
+    j :: rest => json_to_message(j) :: json_to_message_list(rest)
+  }
+}
+
+func json_to_messages(j: Json) -> [Message] {
+  match getArray(j, "messages") {
+    Some(ms) => json_to_message_list(ms),
+    None => []
+  }
+}
+
+func checkpoint_dir(workdir: string) -> string {
+  "${workdir}/.motoko/session"
+}
+
+func checkpoint_path(workdir: string, session_id: string) -> string {
+  "${checkpoint_dir(workdir)}/${session_id}.json"
+}
+
+func write_checkpoint(workdir: string, session_id: string, msgs: [Message]) -> () ! {FS} {
+  let _ = mkdirAllResult(checkpoint_dir(workdir));
+  let body = encode(jo([
+    kv("schema_version", jnum(_int_to_float(1))),
+    kv("session_id", js(session_id)),
+    kv("messages", ja(messages_to_json(msgs)))
+  ]));
+  let _ = writeFileResult(checkpoint_path(workdir, session_id), body);
+  ()
+}
+
+func tool_call_eq(a: ToolCall, b: ToolCall) -> bool {
+  a.id == b.id && a.name == b.name && a.arguments == b.arguments
+}
+
+func tool_calls_eq(a: [ToolCall], b: [ToolCall]) -> bool {
+  match a {
+    [] => match b { [] => true, _ => false },
+    ah :: at => match b {
+      [] => false,
+      bh :: bt => tool_call_eq(ah, bh) && tool_calls_eq(at, bt)
+    }
+  }
+}
+
+func message_eq(a: Message, b: Message) -> bool {
+  a.role == b.role
+    && a.content == b.content
+    && tool_calls_eq(a.tool_calls, b.tool_calls)
+    && a.tool_call_id == b.tool_call_id
+}
+
+func messages_eq(a: [Message], b: [Message]) -> bool {
+  match a {
+    [] => match b { [] => true, _ => false },
+    ah :: at => match b {
+      [] => false,
+      bh :: bt => message_eq(ah, bh) && messages_eq(at, bt)
+    }
+  }
+}
+
+pure func test_checkpoint_message_codec_preserves_tool_calls() -> bool
+  tests [((), true)]
+  {
+    let assistant_call: ToolCall = {
+      id: "call_1",
+      name: "BashExec",
+      arguments: "{\"cmd\":\"pwd\"}"
+    };
+    let history: [Message] = [
+      { role: "system", content: "system", tool_calls: [], tool_call_id: "" },
+      { role: "user", content: "run pwd", tool_calls: [], tool_call_id: "" },
+      { role: "assistant", content: "", tool_calls: [assistant_call], tool_call_id: "" },
+      { role: "tool", content: "{\"stdout\":\"/tmp\"}", tool_calls: [], tool_call_id: "call_1" }
+    ];
+    let encoded = jo([kv("messages", ja(messages_to_json(history)))]);
+    messages_eq(json_to_messages(encoded), history)
+  }
 
 -- Build a [Message] entry for one assistant turn from the StepResult. Carries
 -- the typed tool_calls verbatim so the model sees its own tool_call IDs on
@@ -1073,6 +1214,7 @@ func loop_v2(
     })
   }
   else {
+  let _ = write_checkpoint(workdir, session_id, msgs);
   -- Build extension context for this step (needed for dispatch_pre_step)
   let ctx = mk_v2_ext_ctx(task, step_idx, model, workdir, env_url, hybrid_tools, budget, msgs);
   
@@ -1550,7 +1692,10 @@ export func conversation_loop_v2(
           kv("mode", js("v2"))
         ]);
         match run_v2_from_messages(rt, content, env_url, hybrid_tools, budget, model, next_history, workdir, step_budget, ohmy_pi, max_cost_millicents, cost_rates, provider) {
-          Ok(updated_history) => conversation_loop_v2(rt, env_url, hybrid_tools, budget, model, updated_history, workdir, step_budget, ohmy_pi, max_cost_millicents, cost_rates, provider, session_id),
+          Ok(updated_history) => {
+            let _ = write_checkpoint(workdir, session_id, updated_history);
+            conversation_loop_v2(rt, env_url, hybrid_tools, budget, model, updated_history, workdir, step_budget, ohmy_pi, max_cost_millicents, cost_rates, provider, session_id)
+          },
           Err(e) => {
             let _ = emit_event(session_id, "error", [
               kv("source", js("agent_loop_v2")),

--- a/src/core/rpc.ail
+++ b/src/core/rpc.ail
@@ -11,10 +11,11 @@ module src/core/rpc
 -- For history of what was here before, see the M-MOTOKO-RPC-LOOP-FULL-
 -- MIGRATION sprint plan + CHANGELOG.md and git log around 2026-05-06.
 
-import src/core/agent_loop_v2 (run_v2_with_conversation)
+import src/core/agent_loop_v2 (run_v2_with_conversation, resume_v2_conversation)
 import src/core/context_usage (context_limit_for)
 import src/core/test/stub_step (LiveAI)
 import std/io     (println, exit)
+import std/env    (getEnvOr)
 import std/json   (Json, encode, jo, ja, kv, js, jb, jnum)
 import std/list   (foldl)
 import std/string (length)
@@ -162,6 +163,10 @@ export func run_with_config(cfg: RuntimeConfig, inv: InvocationConfig) -> () ! {
   let ext_runtime = init_runtime_with_config(cfg);
   let ailang_built = inv.ailang_built;
   let cwd = if inv.workdir_override != "" then inv.workdir_override else cfg.agent.workdir;
+  let session_id = getEnvOr("MOTOKO_SESSION_ID", "");
+  let resume = getEnvOr("MOTOKO_RESUME", "") == "1"
+    && session_id != ""
+    && fileExists("${cwd}/.motoko/session/${session_id}.json");
   let settings = {
     task: task,
     ailang_built: ailang_built,
@@ -180,17 +185,18 @@ export func run_with_config(cfg: RuntimeConfig, inv: InvocationConfig) -> () ! {
     cost_rates: cfg.cost_rates
   };
   let bv = version();
-  let _ = emit(encode(jo([
-    kv("type", js("session_start")),
-    kv("task", js(task)),
-    kv("model", js(model)),
-    kv("brainVersion", js(bv)),
-    kv("ailangBuilt", js(ailang_built)),
-    kv("config_profile", js(cfg.profile)),
-    kv("config_dir", js(cfg.profile_dir)),
-    kv("backend_mode", js(cfg.backend.mode)),
-    kv("loaded_extensions", ja(json_string_values(loaded_extension_names(ext_runtime))))
-  ])));
+  let _ = if resume then ()
+    else emit(encode(jo([
+      kv("type", js("session_start")),
+      kv("task", js(task)),
+      kv("model", js(model)),
+      kv("brainVersion", js(bv)),
+      kv("ailangBuilt", js(ailang_built)),
+      kv("config_profile", js(cfg.profile)),
+      kv("config_dir", js(cfg.profile_dir)),
+      kv("backend_mode", js(cfg.backend.mode)),
+      kv("loaded_extensions", ja(json_string_values(loaded_extension_names(ext_runtime))))
+    ])));
 
   let hint = get_hint(task);
   let system_md_path = cfg.agent.system_prompt;
@@ -234,7 +240,10 @@ export func run_with_config(cfg: RuntimeConfig, inv: InvocationConfig) -> () ! {
     kv("type", js("v2_mode")),
     kv("note", js("running with upstream std/ai.step (typed tool_calls) — M-MOTOKO-RPC-LOOP-FULL-MIGRATION cutover complete"))
   ])));
-  run_v2_with_conversation(ext_runtime, task, env_url, hybrid_enabled, budget, model, init, settings.workdir, budget.total, settings.ohmy_pi, settings.max_cost_millicents, settings.cost_rates, LiveAI)
+  if resume then
+    resume_v2_conversation(ext_runtime, env_url, hybrid_enabled, budget, model, init, settings.workdir, budget.total, settings.ohmy_pi, settings.max_cost_millicents, settings.cost_rates, LiveAI, session_id)
+  else
+    run_v2_with_conversation(ext_runtime, task, env_url, hybrid_enabled, budget, model, init, settings.workdir, budget.total, settings.ohmy_pi, settings.max_cost_millicents, settings.cost_rates, LiveAI)
 }
 
 export func main() -> () ! {Net, AI, SharedMem, IO, Env, FS, Clock, Process, Stream, Trace} {

--- a/src/examples/csp_demo/main.ail
+++ b/src/examples/csp_demo/main.ail
@@ -16,11 +16,11 @@ export func main() -> () ! {Stream, Process, IO} {
 
     selectEvents([proc, stdin], \event. match event {
         SourceBytes(src, data) => {
-            println("[" ++ src ++ " (SUBPROCESS)] " ++ toString(data));
+            println(concat(["[", src, " (SUBPROCESS)] ", toString(data)]));
             true
         },
         SourceText(src, text) => {
-            println("[" ++ src ++ " (STDIN)] You typed: " ++ text);
+            println(concat(["[", src, " (STDIN)] You typed: ", text]));
             false 
         },
         _ => {

--- a/src/examples/recursive_stats.ail
+++ b/src/examples/recursive_stats.ail
@@ -17,9 +17,9 @@ export func main() -> () ! {IO} {
   let stats = calculate_stats(data, 0, 0, 0);
 
   println("--- Recursive Statistics Analysis ---");
-  println("Input Data: " ++ show(data));
-  println("Count: " ++ show(stats.count));
-  println("Sum:   " ++ show(stats.sum));
-  println("Max:   " ++ show(stats.max));
+  println(concat(["Input Data: ", show(data)]));
+  println(concat(["Count: ", show(stats.count)]));
+  println(concat(["Sum:   ", show(stats.sum)]));
+  println(concat(["Max:   ", show(stats.max)]));
   println("--------------------------------------");
 }

--- a/src/examples/task_processor.ail
+++ b/src/examples/task_processor.ail
@@ -21,9 +21,9 @@ pure func filter_completed(tasks: [Task]) -> [Task] {
 }
 
 pure func process_task(t: Task) -> Task ! {IO, AI} {
-  let prompt = "Summarize this task in 5 words: " ++ t.description;
+  let prompt = concat(["Summarize this task in 5 words: ", t.description]);
   let summary = call(prompt);
-  println("AI Summary for Task " ++ show(t.id) ++ ": " ++ summary);
+  println(concat(["AI Summary for Task ", show(t.id), ": ", summary]));
   {t | description: summary}
 }
 
@@ -46,10 +46,10 @@ export func main() -> () ! {IO, AI} {
   ];
 
   let completed_tasks = filter_completed(tasks);
-  println("Found " ++ show(length(completed_tasks)) ++ " completed tasks.");
+  println(concat(["Found ", show(length(completed_tasks)), " completed tasks."]));
 
   let incomplete_tasks = filter_incomplete(tasks);
-  println("Processing " ++ show(length(incomplete_tasks)) ++ " incomplete tasks...");
+  println(concat(["Processing ", show(length(incomplete_tasks)), " incomplete tasks..."]));
   
   let processed_tasks = process_all_tasks(incomplete_tasks);
 
@@ -67,7 +67,7 @@ pure func filter_incomplete(tasks: [Task]) -> [Task] {
 pure func print_descriptions(tasks: [Task]) -> () ! {IO} {
   match tasks {
     [] => (),
-    t :: rest => let _ = println("- " ++ t.description) in print_descriptions(rest)
+    t :: rest => let _ = println(concat(["- ", t.description])) in print_descriptions(rest)
   }
 }
 

--- a/src/tui/package.json
+++ b/src/tui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "bun node_modules/.bin/jest --testPathPattern='src/.*\\.test\\.ts'"
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --testPathPattern='src/.*\\.test\\.ts' --runInBand"
   },
   "dependencies": {
     "@mariozechner/pi-tui": "^0.64.0",

--- a/src/tui/src/index.ts
+++ b/src/tui/src/index.ts
@@ -825,6 +825,7 @@ async function main(): Promise<void> {
   // callbacks, and spawnRuntimeProcess() may be called again on model switch.
   let runtimeProcess: RuntimeProcess | undefined;
   let sessionLogger: SessionLogger | undefined;
+  let sessionId = `session_${new Date().toISOString().replace(/[:.]/g, "-")}`;
   // Set to true when the user presses ESC to interrupt a running task.
   // Prevents the normal process.exit(0) on runtime process exit so the user can
   // submit a new task instead.
@@ -860,6 +861,7 @@ async function main(): Promise<void> {
       systemPrompt,
       openaiBaseUrl,
       aiOptionsJson,
+      process.env.MOTOKO_SESSION_ID ?? "",
       (event) => {
         logger.log(event);
         // For terminal events, drain the JSONL stream BEFORE letting the UI
@@ -906,6 +908,7 @@ async function main(): Promise<void> {
       systemPrompt,
       openaiBaseUrl,
       aiOptionsJson,
+      sessionId,
       (event) => {
         if (event.type === "error") errorOccurred = true;
         logger.log(event);
@@ -927,6 +930,7 @@ async function main(): Promise<void> {
           // Reset interrupted flag for clean restart
           interrupted = false;
           errorOccurred = false;
+          sessionId = `session_${new Date().toISOString().replace(/[:.]/g, "-")}`;
           // Small delay before respawn
           setTimeout(() => spawnRuntimeProcess("", false), 100);
         } else if (interrupted) {
@@ -965,6 +969,7 @@ async function main(): Promise<void> {
       // No running process — start fresh
       profile = newProfile ?? profile;
       ui.setProfile(profile);
+      sessionId = `session_${new Date().toISOString().replace(/[:.]/g, "-")}`;
       spawnRuntimeProcess("", false);
     }
   };

--- a/src/tui/src/index.ts
+++ b/src/tui/src/index.ts
@@ -862,6 +862,7 @@ async function main(): Promise<void> {
       openaiBaseUrl,
       aiOptionsJson,
       process.env.MOTOKO_SESSION_ID ?? "",
+      false,
       (event) => {
         logger.log(event);
         // For terminal events, drain the JSONL stream BEFORE letting the UI
@@ -893,7 +894,21 @@ async function main(): Promise<void> {
 
   const ui = new AgentUI({ version: pkgVersion, model, profile, ailangVersion, extensions: profileAgent.extensions });
 
-  function spawnRuntimeProcess(task: string, logPrompt: boolean): void {
+  function checkpointPathForSession(): string {
+    const id = process.env.MOTOKO_SESSION_ID ?? sessionId;
+    return path.join(workdir, ".motoko", "session", `${id}.json`);
+  }
+
+  function removeSessionCheckpoint(): void {
+    try {
+      fs.rmSync(checkpointPathForSession(), { force: true });
+    } catch {
+      // Best-effort cleanup only; stale checkpoints are ignored unless a future
+      // spawn explicitly requests MOTOKO_RESUME.
+    }
+  }
+
+  function spawnRuntimeProcess(task: string, logPrompt: boolean, resume = false): void {
     errorOccurred = false;
     const logger = new SessionLogger(projectRoot, pkgVersion);
     sessionLogger = logger;
@@ -909,6 +924,7 @@ async function main(): Promise<void> {
       openaiBaseUrl,
       aiOptionsJson,
       sessionId,
+      resume,
       (event) => {
         if (event.type === "error") errorOccurred = true;
         logger.log(event);
@@ -930,13 +946,14 @@ async function main(): Promise<void> {
           // Reset interrupted flag for clean restart
           interrupted = false;
           errorOccurred = false;
+          removeSessionCheckpoint();
           sessionId = `session_${new Date().toISOString().replace(/[:.]/g, "-")}`;
           // Small delay before respawn
           setTimeout(() => spawnRuntimeProcess("", false), 100);
         } else if (interrupted) {
-          // ESC was pressed — don't exit; let the user submit a new task.
+          // ESC was pressed — respawn into the checkpointed conversation.
           interrupted = false;
-          ui.setAwaitingTask(true);
+          setTimeout(() => spawnRuntimeProcess("", false, true), 100);
         } else if (errorOccurred) {
           // Process crashed after emitting an error (unexpected exit on the
           // normal error path).  Recover rather than exiting the TUI.
@@ -944,6 +961,7 @@ async function main(): Promise<void> {
           ui.setAwaitingTask(true);
         } else {
           void closing.then(() => {
+            removeSessionCheckpoint();
             ui.stop();
             process.exit(0);
           });

--- a/src/tui/src/runtime-process.env.test.ts
+++ b/src/tui/src/runtime-process.env.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { buildRuntimeChildEnv } from "./runtime-process.js";
+
+describe("runtime child env", () => {
+  let savedSessionId: string | undefined;
+  let savedResume: string | undefined;
+
+  beforeEach(() => {
+    savedSessionId = process.env.MOTOKO_SESSION_ID;
+    savedResume = process.env.MOTOKO_RESUME;
+    delete process.env.MOTOKO_SESSION_ID;
+    delete process.env.MOTOKO_RESUME;
+  });
+
+  afterEach(() => {
+    if (savedSessionId === undefined) delete process.env.MOTOKO_SESSION_ID;
+    else process.env.MOTOKO_SESSION_ID = savedSessionId;
+    if (savedResume === undefined) delete process.env.MOTOKO_RESUME;
+    else process.env.MOTOKO_RESUME = savedResume;
+  });
+
+  it("exports the stable TUI session id by default", () => {
+    const env1 = buildRuntimeChildEnv("/tmp/work", "default", "session_stable", false);
+    const env2 = buildRuntimeChildEnv("/tmp/work", "default", "session_stable", false);
+
+    expect(env1.MOTOKO_SESSION_ID).toBe("session_stable");
+    expect(env2.MOTOKO_SESSION_ID).toBe("session_stable");
+    expect(env1.MOTOKO_RESUME).toBeUndefined();
+  });
+
+  it("preserves an adapter-provided MOTOKO_SESSION_ID", () => {
+    process.env.MOTOKO_SESSION_ID = "session_from_env";
+    const env = buildRuntimeChildEnv("/tmp/work", "default", "session_tui", false);
+
+    expect(env.MOTOKO_SESSION_ID).toBe("session_from_env");
+  });
+
+  it("sets MOTOKO_RESUME only for interrupt respawns", () => {
+    const normal = buildRuntimeChildEnv("/tmp/work", "default", "session_stable", false);
+    const resumed = buildRuntimeChildEnv("/tmp/work", "default", "session_stable", true);
+
+    expect(normal.MOTOKO_RESUME).toBeUndefined();
+    expect(resumed.MOTOKO_RESUME).toBe("1");
+  });
+});

--- a/src/tui/src/runtime-process.stream-protocol.test.ts
+++ b/src/tui/src/runtime-process.stream-protocol.test.ts
@@ -37,6 +37,14 @@ describe("stream protocol decoder", () => {
     expect(JSON.parse(evt.cells_json)).toEqual(cells);
   });
 
+  it("parses session_resume events", () => {
+    const evt = parseAgentEventLine('{"type":"session_resume","session_id":"session_a","model":"test/model","restored_messages":4}');
+    expect(evt?.type).toBe("session_resume");
+    if (evt?.type !== "session_resume") return;
+    expect(evt.model).toBe("test/model");
+    expect(evt.restored_messages).toBe(4);
+  });
+
   it("returns null for malformed or non-event lines", () => {
     expect(parseAgentEventLine("")).toBeNull();
     expect(parseAgentEventLine("not-json")).toBeNull();

--- a/src/tui/src/runtime-process.ts
+++ b/src/tui/src/runtime-process.ts
@@ -55,6 +55,7 @@ export type ToolResultsPhase = "running" | "progress" | "done";
 
 export type AgentEvent =
   | { type: "session_start"; task: string; model: string; brainVersion: string; ailangBuilt: string; config_profile?: string; config_dir?: string; loaded_extensions?: string[] }
+  | { type: "session_resume"; session_id?: string; model: string; restored_messages: number }
   | { type: "context_usage"; step: number; tokens_est: number; limit: number }
   | { type: "thinking_stream_start"; step: number; stream_id: string; model: string }
   | { type: "thinking_delta"; step: number; stream_id: string; seq: number; text_delta: string }
@@ -271,6 +272,80 @@ function mirrorAbsoluteProfile(workdir: string, profile: string): string {
   return basename;
 }
 
+export function buildRuntimeChildEnv(
+  workdir: string,
+  profile: string,
+  sessionId: string,
+  resume: boolean,
+): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH,
+    HOME: process.env.HOME,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+    GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+    EXA_API_KEY: process.env.EXA_API_KEY,
+    CLICKSTACK_INGESTION_KEY: process.env.CLICKSTACK_INGESTION_KEY,
+    AILANG_FS_SANDBOX: workdir,
+    MOTOKO_STREAM_EVENTS: process.env.MOTOKO_STREAM_EVENTS ?? "1",
+    MOTOKO_SESSION_ID: process.env.MOTOKO_SESSION_ID ?? sessionId,
+    // M-MOTOKO-HEADLESS (2026-05-08): when stdin is not a TTY, set
+    // MOTOKO_HEADLESS=1 so the AILANG runtime's conversation_loop_v2
+    // skips its readLine() drain (which blocks indefinitely on non-TTY
+    // stdin instead of returning EOF) and exits cleanly after the first
+    // task completes. Manual override: set MOTOKO_HEADLESS in the parent
+    // env to force either mode regardless of TTY state.
+    // See agent_loop_v2.ail conversation_loop_v2 for the AILANG-side gate.
+    MOTOKO_HEADLESS:
+      process.env.MOTOKO_HEADLESS ??
+      (process.stdin.isTTY ? "" : "1"),
+    // M-MOTOKO-PERSIST-NUDGE: forward the loop-persistence retry budget so
+    // agent_loop_v2.ail's NoDecision branch can read it. Without this the
+    // explicit env allowlist scrubs it and the feature is silently off —
+    // same gotcha as MOTOKO_REPO / the pricing vars below. Empty = off.
+    MOTOKO_PERSIST_RETRIES: process.env.MOTOKO_PERSIST_RETRIES ?? "",
+    // M-MOTOKO-EVAL-HARNESS-HARDENING gap #6 (2026-05-08): forward
+    // MOTOKO_REPO so the AILANG runtime can fall back to the fork's
+    // bundled profile (.motoko/config/<profile>) when WORKDIR is a
+    // per-task scratch dir without its own .motoko/config. Without
+    // this, eval-harness runs see extensions.order=[] and other
+    // profile defaults silently mask user-configured behavior.
+    MOTOKO_REPO: process.env.MOTOKO_REPO ?? "",
+    // MOTOKO_PROFILE_DIR — absolute path to the active profile's config
+    // directory. Standalone AILANG extension packages (motoko-ext-*) read
+    // their own JSON config here (e.g. motoko-ext-compaction-ai reads
+    // ${MOTOKO_PROFILE_DIR}/compaction_ai.json). Without this var, the
+    // packages fall back to "." which resolves to the AILANG runtime's
+    // CWD (motoko_agent root) → "no such file or directory" panics on
+    // first turn. The original src/core/config.ail path-built the same
+    // location internally; the env-var split happened when extensions
+    // moved out into separate packages without a corresponding launcher
+    // wiring.
+    MOTOKO_PROFILE_DIR: path.resolve(workdir, ".motoko", "config", profile),
+    // M-OLLAMA-PER-MODEL-MAX-TOKENS: forward the per-model output budget so the
+    // AILANG runtime's ollama /v1 path (resolveOllamaMaxTokens) uses the model's
+    // declared max_output_tokens instead of the 4096 std/ai default. Qwen3.6
+    // reasons thousands of tokens before the tool call and truncates
+    // (finish_reason=length) at 4096 → 0 tool calls (disengagement). Without this
+    // allowlist entry the explicit childEnv whitelist drops it — same gotcha as
+    // MOTOKO_REPO / the pricing vars. Empty = the AILANG-side 16384 floor applies.
+    AILANG_OLLAMA_MAX_TOKENS: process.env.AILANG_OLLAMA_MAX_TOKENS ?? "",
+    // M-MOTOKO-EVAL-HARNESS-HARDENING M5 follow-up (2026-05-08): forward
+    // pricing env vars set by the AILANG adapter from Task.Budget. Without
+    // this, the AILANG-side fix (load_cost_rates reads these env vars) is
+    // a no-op because the explicit whitelist drops them — same gotcha as
+    // MOTOKO_REPO above (gap #6). Empty string falls through to motoko's
+    // profile config fallback inside load_cost_rates.
+    MOTOKO_COST_INPUT_PER_1M_MILLICENTS:
+      process.env.MOTOKO_COST_INPUT_PER_1M_MILLICENTS ?? "",
+    MOTOKO_COST_OUTPUT_PER_1M_MILLICENTS:
+      process.env.MOTOKO_COST_OUTPUT_PER_1M_MILLICENTS ?? "",
+  };
+  if (resume) childEnv.MOTOKO_RESUME = "1";
+  return childEnv;
+}
+
 export class RuntimeProcess {
   private proc: ChildProcess;
   private dead = false;
@@ -289,6 +364,7 @@ export class RuntimeProcess {
     openaiBaseUrl: string,
     aiOptionsJson: string,
     sessionId: string,
+    resume: boolean,
     onEvent: (e: AgentEvent) => void,
     onExit: () => void
   ) {
@@ -299,70 +375,7 @@ export class RuntimeProcess {
     const ailangBin = (process.env.AILANG_BIN && process.env.AILANG_BIN.trim() !== "")
       ? process.env.AILANG_BIN
       : "ailang";
-    const childEnv: NodeJS.ProcessEnv = {
-      PATH: process.env.PATH,
-      HOME: process.env.HOME,
-      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
-      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-      OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
-      GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
-      EXA_API_KEY: process.env.EXA_API_KEY,
-      CLICKSTACK_INGESTION_KEY: process.env.CLICKSTACK_INGESTION_KEY,
-      AILANG_FS_SANDBOX: workdir,
-      MOTOKO_STREAM_EVENTS: process.env.MOTOKO_STREAM_EVENTS ?? "1",
-      MOTOKO_SESSION_ID: process.env.MOTOKO_SESSION_ID ?? this.sessionId,
-      // M-MOTOKO-HEADLESS (2026-05-08): when stdin is not a TTY, set
-      // MOTOKO_HEADLESS=1 so the AILANG runtime's conversation_loop_v2
-      // skips its readLine() drain (which blocks indefinitely on non-TTY
-      // stdin instead of returning EOF) and exits cleanly after the first
-      // task completes. Manual override: set MOTOKO_HEADLESS in the parent
-      // env to force either mode regardless of TTY state.
-      // See agent_loop_v2.ail conversation_loop_v2 for the AILANG-side gate.
-      MOTOKO_HEADLESS:
-        process.env.MOTOKO_HEADLESS ??
-        (process.stdin.isTTY ? "" : "1"),
-      // M-MOTOKO-PERSIST-NUDGE: forward the loop-persistence retry budget so
-      // agent_loop_v2.ail's NoDecision branch can read it. Without this the
-      // explicit env allowlist scrubs it and the feature is silently off —
-      // same gotcha as MOTOKO_REPO / the pricing vars below. Empty = off.
-      MOTOKO_PERSIST_RETRIES: process.env.MOTOKO_PERSIST_RETRIES ?? "",
-      // M-MOTOKO-EVAL-HARNESS-HARDENING gap #6 (2026-05-08): forward
-      // MOTOKO_REPO so the AILANG runtime can fall back to the fork's
-      // bundled profile (.motoko/config/<profile>) when WORKDIR is a
-      // per-task scratch dir without its own .motoko/config. Without
-      // this, eval-harness runs see extensions.order=[] and other
-      // profile defaults silently mask user-configured behavior.
-      MOTOKO_REPO: process.env.MOTOKO_REPO ?? "",
-      // MOTOKO_PROFILE_DIR — absolute path to the active profile's config
-      // directory. Standalone AILANG extension packages (motoko-ext-*) read
-      // their own JSON config here (e.g. motoko-ext-compaction-ai reads
-      // ${MOTOKO_PROFILE_DIR}/compaction_ai.json). Without this var, the
-      // packages fall back to "." which resolves to the AILANG runtime's
-      // CWD (motoko_agent root) → "no such file or directory" panics on
-      // first turn. The original src/core/config.ail path-built the same
-      // location internally; the env-var split happened when extensions
-      // moved out into separate packages without a corresponding launcher
-      // wiring.
-      MOTOKO_PROFILE_DIR: path.resolve(workdir, ".motoko", "config", profile),
-      // M-OLLAMA-PER-MODEL-MAX-TOKENS: forward the per-model output budget so the
-      // AILANG runtime's ollama /v1 path (resolveOllamaMaxTokens) uses the model's
-      // declared max_output_tokens instead of the 4096 std/ai default. Qwen3.6
-      // reasons thousands of tokens before the tool call and truncates
-      // (finish_reason=length) at 4096 → 0 tool calls (disengagement). Without this
-      // allowlist entry the explicit childEnv whitelist drops it — same gotcha as
-      // MOTOKO_REPO / the pricing vars. Empty = the AILANG-side 16384 floor applies.
-      AILANG_OLLAMA_MAX_TOKENS: process.env.AILANG_OLLAMA_MAX_TOKENS ?? "",
-      // M-MOTOKO-EVAL-HARNESS-HARDENING M5 follow-up (2026-05-08): forward
-      // pricing env vars set by the AILANG adapter from Task.Budget. Without
-      // this, the AILANG-side fix (load_cost_rates reads these env vars) is
-      // a no-op because the explicit whitelist drops them — same gotcha as
-      // MOTOKO_REPO above (gap #6). Empty string falls through to motoko's
-      // profile config fallback inside load_cost_rates.
-      MOTOKO_COST_INPUT_PER_1M_MILLICENTS:
-        process.env.MOTOKO_COST_INPUT_PER_1M_MILLICENTS ?? "",
-      MOTOKO_COST_OUTPUT_PER_1M_MILLICENTS:
-        process.env.MOTOKO_COST_OUTPUT_PER_1M_MILLICENTS ?? "",
-    };
+    const childEnv = buildRuntimeChildEnv(workdir, profile, this.sessionId, resume);
     // AILANG v0.15.x migration: forward AILANG_STDLIB_PATH if set in the
     // parent env so callers can point the runtime at an upstream stdlib
     // checkout (e.g. /Users/mark/dev/sunholo/ailang/std). Without this,

--- a/src/tui/src/runtime-process.ts
+++ b/src/tui/src/runtime-process.ts
@@ -276,6 +276,7 @@ export class RuntimeProcess {
   private dead = false;
   private readonly workdir: string;
   private readonly onEvent: (e: AgentEvent) => void;
+  private readonly sessionId: string;
 
   constructor(
     task: string,
@@ -287,11 +288,13 @@ export class RuntimeProcess {
     systemPrompt: string,
     openaiBaseUrl: string,
     aiOptionsJson: string,
+    sessionId: string,
     onEvent: (e: AgentEvent) => void,
     onExit: () => void
   ) {
     this.workdir = workdir;
     this.onEvent = onEvent;
+    this.sessionId = sessionId;
     const aiModelArg = model;
     const ailangBin = (process.env.AILANG_BIN && process.env.AILANG_BIN.trim() !== "")
       ? process.env.AILANG_BIN
@@ -307,6 +310,7 @@ export class RuntimeProcess {
       CLICKSTACK_INGESTION_KEY: process.env.CLICKSTACK_INGESTION_KEY,
       AILANG_FS_SANDBOX: workdir,
       MOTOKO_STREAM_EVENTS: process.env.MOTOKO_STREAM_EVENTS ?? "1",
+      MOTOKO_SESSION_ID: process.env.MOTOKO_SESSION_ID ?? this.sessionId,
       // M-MOTOKO-HEADLESS (2026-05-08): when stdin is not a TTY, set
       // MOTOKO_HEADLESS=1 so the AILANG runtime's conversation_loop_v2
       // skips its readLine() drain (which blocks indefinitely on non-TTY

--- a/src/tui/src/session-logger.ts
+++ b/src/tui/src/session-logger.ts
@@ -278,6 +278,10 @@ export class SessionLogger {
           this.writeTranscriptLine(`Loaded extensions: ${extText}`);
         }
         break;
+      case "session_resume":
+        this.setState("idle");
+        this.writeTranscriptLine(`Resumed ${event.restored_messages} messages`);
+        break;
       case "thinking":
         this.ensureThinkingLine();
         {

--- a/src/tui/src/ui.ts
+++ b/src/tui/src/ui.ts
@@ -2022,6 +2022,7 @@ export class AgentUI {
   private selectedScratchpadIdx = -1;
   private readonly thinkStepOrder: number[] = [];  // insertion order; used for ctrl+t cycling
   private selectedThinkIdx = -1;                   // index into thinkStepOrder, -1 = none selected
+  private interruptPending = false;
   /** True once the first task is complete; enables free-text follow-ups. */
   private taskDone = false;
   /** Package version shown as a startup banner in the history pane. */
@@ -2151,6 +2152,8 @@ export class AgentUI {
       // ESC while a task is running: kill the runtime process immediately.
       // Do NOT consume ESC when idle — let Editor handle it (e.g. cancel autocomplete).
       if (matchesKey(data, "escape") && this.runtimeProcess && !this.taskDone) {
+        if (this.interruptPending) return { consume: true };
+        this.interruptPending = true;
         this.appendHistoryStyled("Task interrupted", chalk.yellow);
         this.tui.requestRender();
         this.onInterrupt?.();
@@ -2303,6 +2306,7 @@ export class AgentUI {
     this.lastUpdateMs = Date.now();
     switch (event.type) {
       case "session_start":
+        this.interruptPending = false;
         this.composeFooterStatus = "";
         this.toolOutputExpanded = true;
         this.refreshAllToolDetailRows();
@@ -2337,6 +2341,7 @@ export class AgentUI {
         break;
 
       case "session_resume":
+        this.interruptPending = false;
         this.composeFooterStatus = "";
         this.toolOutputExpanded = true;
         this.refreshAllToolDetailRows();
@@ -2739,6 +2744,7 @@ export class AgentUI {
         break;
 
       case "done":
+        this.interruptPending = false;
         if (event.output && event.output.trim()) {
           const visible = this.stripToolJsonBlocks(event.output).trim();
           const tagged = extractTaggedThinkAnswer(visible);
@@ -2765,6 +2771,7 @@ export class AgentUI {
         this.appendHistoryStyled(`Warning: ${event.message}`, chalk.yellow);
         break;
       case "error":
+        this.interruptPending = false;
         this.composeFooterStatus = "";
         this.setRunState("error");
         this.appendHistoryStyled(`Error: ${event.message}`, chalk.redBright);
@@ -4006,6 +4013,7 @@ export class AgentUI {
 
   setAwaitingTask(waiting: boolean): void {
     this.awaitingTask = waiting;
+    if (waiting) this.interruptPending = false;
     if (waiting) this.setRunState("idle");
     this.updateStatus();
   }

--- a/src/tui/src/ui.ts
+++ b/src/tui/src/ui.ts
@@ -1794,6 +1794,19 @@ export function shouldLockPlainInput(
   return !awaitingTask && !taskDone && value.length > 0 && !value.startsWith("/");
 }
 
+export type PlainInputRoute = "initial" | "followup" | "locked" | "unknown";
+
+export function plainInputRoute(
+  awaitingTask: boolean,
+  taskDone: boolean,
+  value: string,
+): PlainInputRoute {
+  if (awaitingTask && value && !value.startsWith("/")) return "initial";
+  if (taskDone && value && !value.startsWith("/")) return "followup";
+  if (shouldLockPlainInput(awaitingTask, taskDone, value)) return "locked";
+  return "unknown";
+}
+
 function initialExtensionsFromEnv(): string {
   const raw = (process.env.CORE_EXT_ORDER ?? "").trim();
   if (raw === "") return "";
@@ -2321,6 +2334,19 @@ export class AgentUI {
           this.scratchpadExtensionActive = hasScratchpadExtension(names);
           this.appendHistoryStyled(`Loaded extensions: ${extText}`, chalk.dim);
         }
+        break;
+
+      case "session_resume":
+        this.composeFooterStatus = "";
+        this.toolOutputExpanded = true;
+        this.refreshAllToolDetailRows();
+        this.model = event.model;
+        this.setRunState("idle");
+        this.awaitingTask = false;
+        this.taskDone = true;
+        this.tui.setFocus(this.cmdInput);
+        this.appendHistoryStyled(`Resumed ${event.restored_messages} messages`, chalk.dim);
+        this.updateStatus();
         break;
 
       case "thinking":
@@ -3996,8 +4022,10 @@ export class AgentUI {
       return;
     }
 
+    const route = plainInputRoute(this.awaitingTask, this.taskDone, value);
+
     // Before any task has started, treat the first plain-text submission as the task.
-    if (this.awaitingTask && value && !value.startsWith("/")) {
+    if (route === "initial") {
       this.awaitingTask = false;
       this.appendHistoryStyled(`> ${value}`, chalk.cyan);
       this.tui.requestRender();
@@ -4006,7 +4034,7 @@ export class AgentUI {
     }
 
     // After task completion, plain text (not starting with '/') is a follow-up.
-    if (this.taskDone && value && !value.startsWith("/")) {
+    if (route === "followup") {
       this.appendHistoryStyled(`> ${value}`, chalk.cyan);
       this.onUserMessage?.(value);
       // Reset taskDone — runtime process is now processing again; next done re-enables it.
@@ -4017,7 +4045,7 @@ export class AgentUI {
       return;
     }
 
-    if (shouldLockPlainInput(this.awaitingTask, this.taskDone, value)) {
+    if (route === "locked") {
       this.appendHistoryStyled("Input locked: task still running. Use /abort to stop.", chalk.dim);
       this.tui.requestRender();
       return;

--- a/src/tui/src/ui.wait-state.test.ts
+++ b/src/tui/src/ui.wait-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
-import { applyToolProgressCounters, computeMissingDoneResultIds, shouldLockPlainInput, type ToolBatchCounters } from "./ui.js";
+import { applyToolProgressCounters, computeMissingDoneResultIds, plainInputRoute, shouldLockPlainInput, type ToolBatchCounters } from "./ui.js";
 
 describe("ui wait-state helpers", () => {
   it("locks plain text input only during active runs", () => {
@@ -7,6 +7,12 @@ describe("ui wait-state helpers", () => {
     expect(shouldLockPlainInput(true, false, "new task")).toBe(false);
     expect(shouldLockPlainInput(false, true, "follow up")).toBe(false);
     expect(shouldLockPlainInput(false, false, "/abort")).toBe(false);
+  });
+
+  it("routes plain text as a follow-up after resume marks the task done", () => {
+    expect(plainInputRoute(false, true, "what was my last prompt?")).toBe("followup");
+    expect(plainInputRoute(true, false, "new task")).toBe("initial");
+    expect(plainInputRoute(false, false, "still running")).toBe("locked");
   });
 
   it("applies tool progress counters with dedupe and mixed status", () => {


### PR DESCRIPTION
# Preserve context across ESC abort

Fixes #15

## Summary

This PR implements the Option A checkpoint/rehydrate path from
`.agent/plans/steering_capability/Abort_Context_Persistence_Option_A.md`.

Pressing ESC currently hard-kills the AILANG runtime. Because the v2 conversation
history lives in process memory, the next prompt starts from an empty context. This
change makes ESC recovery explicit:

- The TUI creates and reuses one stable `MOTOKO_SESSION_ID` for a logical session.
- The AILANG v2 loop checkpoints typed `[Message]` history to
  `.motoko/session/<session_id>.json` at step boundaries.
- After ESC, the TUI respawns the runtime with `MOTOKO_RESUME=1`.
- The runtime loads the checkpoint best-effort and emits `session_resume`.
- The UI treats the next plain input as a follow-up message, not a fresh task.
- Clean exits and restarts remove the transient checkpoint.

The checkpoint is intentionally transient crash-recovery state, not a durable session
store. A separate follow-up note captures a possible explicit persistent resume feature.

## What Changed

### TUI runtime lifecycle

- Added stable interactive session id generation and forwarding via
  `MOTOKO_SESSION_ID`.
- Added a resume flag through `spawnRuntimeProcess` / `RuntimeProcess`, exported as
  `MOTOKO_RESUME=1` only for the post-ESC respawn.
- On ESC runtime exit, respawn immediately into resume mode instead of calling
  `setAwaitingTask(true)`.
- Delete the transient checkpoint on clean exit and `/restart`.
- Ignore repeated ESC key events while the first interrupt is still pending, preventing
  duplicate `Task interrupted` lines.

### AILANG checkpoint and resume

- Added a `Message`/`ToolCall` JSON codec inside `agent_loop_v2.ail`.
- Added best-effort checkpoint writes using `mkdirAllResult` and `writeFileResult`.
- Added checkpoint loading with `readFileResult`, `std/json.repair` retry, and fallback
  to init history on missing/corrupt checkpoints.
- Added `resume_v2_conversation` and `session_resume` event emission.
- Gated `rpc.ail` so `session_start` and `session_resume` are mutually exclusive for a
  spawn.
- Kept `rpc.ail` codec-free; typed message/JSON logic stays in `agent_loop_v2.ail`.

### UI and logging

- Added `session_resume` to the TUI event protocol.
- Added UI handling that sets the run state to idle and enables follow-up routing.
- Added transcript logging for resumed sessions.
- Added a pure input-routing helper and regression coverage for the follow-up route.

### Tests and docs

- Added AILANG codec and repair-recovery tests.
- Added TUI env tests for `MOTOKO_SESSION_ID` and `MOTOKO_RESUME`.
- Added stream-protocol coverage for `session_resume`.
- Added UI routing coverage for post-resume follow-up input.
- Updated the TUI test script to run Jest under Node with ESM support via
  `bun run test`.
- Added plan and handoff docs under `.agent/plans/steering_capability/`.
- Added `Persistent_Session_Resume_Followup.md` for a future durable session resume
  feature.

### Other branch changes

- `.gitignore` now ignores `.motoko/session`.
- A few example AILANG files switch string concatenation sites to `concat([...])`.

## Validation

Automated validation run during implementation:

- `make check_core`
- `make test`
- `cd src/tui && bun run build`
- `cd src/tui && bun run test`
- Focused AILANG test: `ailang test src/core/agent_loop_v2.ail`
- Noninteractive resume smoke: pre-created `.motoko/session/<id>.json`, launched with
  `MOTOKO_RESUME=1`, and confirmed `session_resume` emitted with restored messages and
  no startup `session_start` event.

Note: `bun run test` prints an existing `test/path-guard.test.ts` diagnostic about
`process.exit(0)`, but exits successfully.

## Manual Acceptance Scenario

Expected behavior after this PR:

1. Start `make run`.
2. Ask: `Read README.md and run ailang prompt`.
3. Press ESC mid-task.
4. Ask: `What was my last prompt?`.
5. The resumed agent should reference the README task instead of reporting no prior
   context.

During the interrupted run, `.motoko/session/<id>.json` should exist. After clean exit,
the checkpoint should be removed.

## Risk Notes

- The checkpoint is a pre-step snapshot, so it does not preserve partial output from the
  interrupted in-flight step.
- Checkpoint writes are best-effort and must not abort a task.
- Corrupt/truncated checkpoint reads fall back through `json.repair`, then to init
  history if unrecoverable.
- Durable cross-session resume is explicitly out of scope for this PR.
