### PR TITLE
fix(runtime): forward AILANG_OLLAMA_HTTP_TIMEOUT_SEC to the ailang child

### DIFF
--- a/src/tui/src/runtime-process.ts
+++ b/src/tui/src/runtime-process.ts
@@ -348,6 +348,12 @@ export class RuntimeProcess {
       // allowlist entry the explicit childEnv whitelist drops it — same gotcha as
       // MOTOKO_REPO / the pricing vars. Empty = the AILANG-side 16384 floor applies.
       AILANG_OLLAMA_MAX_TOKENS: process.env.AILANG_OLLAMA_MAX_TOKENS ?? "",
+      // Forward the ollama /v1 HTTP timeout (AILANG default 300s). Large-context tasks
+      // accumulate a big prompt; a single qwen request can exceed 5 min on a local GPU and
+      // the AILANG runtime aborts with `context deadline exceeded`, killing the run mid-task.
+      // Without this allowlist entry the var set by the launcher is dropped — same gotcha as
+      // AILANG_OLLAMA_MAX_TOKENS above.
+      AILANG_OLLAMA_HTTP_TIMEOUT_SEC: process.env.AILANG_OLLAMA_HTTP_TIMEOUT_SEC ?? "",
       // M-MOTOKO-EVAL-HARNESS-HARDENING M5 follow-up (2026-05-08): forward
       // pricing env vars set by the AILANG adapter from Task.Budget. Without
       // this, the AILANG-side fix (load_cost_rates reads these env vars) is


### PR DESCRIPTION
The \`childEnv\` allowlist in \`spawnRuntimeProcess()\` (src/tui/src/runtime-process.ts) drops \`AILANG_OLLAMA_HTTP_TIMEOUT_SEC\`, so the spawned AILANG runtime always uses its **300s default** ollama \`/v1\` timeout regardless of what the launcher sets.

**Symptom:** on large-context tasks (e.g. reimplementing a ~530-line file where the agent reads several dependency files first), the accumulated prompt makes a single qwen request exceed 5 minutes on a local GPU, and the AILANG runtime aborts the whole run with:
\`\`\`
[error] Post "http://localhost:11434/v1/chat/completions": context deadline exceeded
\`\`\`
mid-task (observed at step 14 and step 27 in two runs). Setting \`AILANG_OLLAMA_HTTP_TIMEOUT_SEC=1800\` in the launcher had no effect because this allowlist silently drops it.

**Fix:** forward the var, exactly mirroring the existing \`AILANG_OLLAMA_MAX_TOKENS\` line directly above it. AILANG already reads \`AILANG_OLLAMA_HTTP_TIMEOUT_SEC\` correctly (internal/ai/ollama/step.go wires it into both the request context and the http.Client) — it just never arrives.

**Validation:** the propagation mechanism is identical to the proven \`AILANG_OLLAMA_MAX_TOKENS\` passthrough. Marked draft pending an end-to-end large-context re-run (local GPU was in its nightly blackout when this was prepared).

Found while running a large-context AILANG eval (docx parser reimplementation) with qwen3.6 via ollama.