### PR TITLE
feat(tools): EditDecl — AST-span decl-replace tool (kill large-file rewrite-thrash)

### DIFF
--- a/src/core/tool_catalog.ail
+++ b/src/core/tool_catalog.ail
@@ -66,6 +66,12 @@ pure func search_schema() -> ToolSchema = {
 
 -- The full tool catalog motoko_agent advertises to the model. Pass this
 -- to upstream `runTools(model, msgs, tools(), dispatch, budget)`.
+pure func edit_decl_schema() -> ToolSchema = {
+  name: "EditDecl",
+  description: "Replace ONE top-level declaration (function/type) by name via its parsed AST span; the rest of the file is preserved byte-for-byte. Prefer this for whole-decl rewrites in a large file (far cheaper than re-emitting the file with WriteFile). Use EditFile for small intra-decl substring edits; WriteFile for new files.",
+  parameters: "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"},\"decl\":{\"type\":\"string\",\"description\":\"Top-level declaration name to replace\"},\"new_body\":{\"type\":\"string\",\"description\":\"Full new source text for the declaration\"}},\"required\":[\"path\",\"decl\",\"new_body\"]}"
+}
+
 export pure func tools() -> [ToolSchema] {
   [
     read_file_schema(),
@@ -73,7 +79,8 @@ export pure func tools() -> [ToolSchema] {
     edit_file_schema(),
     bash_exec_schema(),
     run_tests_schema(),
-    search_schema()
+    search_schema(),
+    edit_decl_schema()
   ]
 }
 

--- a/src/core/tool_runtime.ail
+++ b/src/core/tool_runtime.ail
@@ -633,7 +633,7 @@ func run_edit_decl(id: string, path: string, decl: string, new_body: string, wor
         let tmp = "${resolved}.editdecl.new";
         match writeFileResult(tmp, new_body) {
           Err(msg) => ToolErrorResult({ id: id, tool: "EditDecl", message: "cannot stage new body: ${msg}" }),
-          Ok(_) => match exec("ailang", ["ast-edit", "replace", "--file", resolved, "--decl", decl, "--new", tmp, "--in-place", "--relax-modules"]) {
+          Ok(_) => match exec("ailang", ["ast-edit", "replace", "--file", resolved, "--decl", decl, "--new", tmp, "--in-place"]) {
             Err(err) => ToolErrorResult({ id: id, tool: "EditDecl", message: process_error_to_string(err) }),
             Ok(out) =>
               if out.exitCode == 0 then

--- a/src/core/tool_runtime.ail
+++ b/src/core/tool_runtime.ail
@@ -141,7 +141,7 @@ func parse_edit_ops_rec(xs: [Json]) -> [EditOp] {
 }
 
 export pure func backend_for(call: ToolCallEnvelope, ohmy_pi: bool) -> ToolBackend {
-  if call.tool == "ReadFile" || call.tool == "WriteFile" || call.tool == "EditFile" || call.tool == "Search" then
+  if call.tool == "ReadFile" || call.tool == "WriteFile" || call.tool == "EditFile" || call.tool == "Search" || call.tool == "EditDecl" then
     if ohmy_pi then Delegated else Native
   else if call.tool == "BashExec" || call.tool == "RunTests" then
     if needs_delegation_for_process(parse_exec_from_args(call.arguments)) then Delegated else Native
@@ -172,6 +172,8 @@ func run_native_call(call: ToolCallEnvelope, workdir: string) -> ToolResultItem 
     run_write_file(call.id, arg_string(args, "path", ""), arg_string(args, "content", ""), workdir)
   else if call.tool == "EditFile" then
     run_edit_file(call.id, arg_string(args, "path", ""), parse_edit_ops(arg_json(args, "edits")), arg_bool(args, "dry_run", false), arg_string(args, "expected_sha256", ""), workdir)
+  else if call.tool == "EditDecl" then
+    run_edit_decl(call.id, arg_string(args, "path", ""), arg_string(args, "decl", ""), arg_string(args, "new_body", ""), workdir)
   else if call.tool == "BashExec" then
     run_process_result("BashExec", call.id, parse_exec_from_args(args))
   else if call.tool == "RunTests" then
@@ -618,6 +620,33 @@ func run_write_file(id: string, path: string, content: string, workdir: string) 
   }
 }
 
+func run_edit_decl(id: string, path: string, decl: string, new_body: string, workdir: string) -> ToolResultItem ! {FS, Process} {
+  match validate_path_common("EditDecl", id, path, workdir) {
+    Err(e) => e,
+    Ok(_) => {
+      let resolved = resolve_workdir_path(workdir, path);
+      if not fileExists(resolved) then
+        ToolErrorResult({ id: id, tool: "EditDecl", message: "file does not exist: ${path}" })
+      else {
+        -- Stage the new declaration source, then splice it by parsed AST span via
+        -- `ailang ast-edit replace` (preserves the rest of the file byte-for-byte).
+        let tmp = "${resolved}.editdecl.new";
+        match writeFileResult(tmp, new_body) {
+          Err(msg) => ToolErrorResult({ id: id, tool: "EditDecl", message: "cannot stage new body: ${msg}" }),
+          Ok(_) => match exec("ailang", ["ast-edit", "replace", "--file", resolved, "--decl", decl, "--new", tmp, "--in-place", "--relax-modules"]) {
+            Err(err) => ToolErrorResult({ id: id, tool: "EditDecl", message: process_error_to_string(err) }),
+            Ok(out) =>
+              if out.exitCode == 0 then
+                WriteFileResult({ id: id, path: path, bytes_written: length(new_body), sha256: sha256Hex(new_body), diff: "(EditDecl: replaced top-level decl '${decl}')" })
+              else
+                ToolErrorResult({ id: id, tool: "EditDecl", message: "ast-edit replace failed (decl '${decl}' not found?): ${toString(out.stderr)}" })
+          }
+        }
+      }
+    }
+  }
+}
+
 func path_dirname(path: string) -> string {
   if startsWith(path, "/") then {
     let rel = substring(path, 1, length(path));
@@ -993,7 +1022,7 @@ func t_normalize_relative_path() -> bool
 -- use the normal delegation check (streaming/hard-cancel requirements).
 -- See: design_docs/planned/m-motoko-path-doubling-v2.md
 export pure func backend_for_v2(call: ToolCallEnvelope, ohmy_pi: bool) -> ToolBackend {
-  if call.tool == "ReadFile" || call.tool == "WriteFile" || call.tool == "EditFile" || call.tool == "Search" then
+  if call.tool == "ReadFile" || call.tool == "WriteFile" || call.tool == "EditFile" || call.tool == "Search" || call.tool == "EditDecl" then
     Native
   else
     backend_for(call, ohmy_pi)


### PR DESCRIPTION
Adds an **EditDecl** tool: replace ONE top-level declaration by name via its parsed AST span (`ailang ast-edit replace --in-place`), preserving the rest of the file byte-for-byte. The model emits a single decl instead of re-writing the whole file (WriteFile) — far fewer output tokens, far less syntax drift on long files.

**Motivation:** the docx_reimplement P0 large-context run had motoko write a 727-line file from a stub; at that volume qwen3.6's AILANG syntax fidelity degraded (Haskell `\x.` lambdas, bad `match` arms) and the package didn't compile. EditDecl bounds each edit to one declaration. Design: `design_docs/planned/m-motoko-editdecl-astedit.md` (in the ailang repo).

**Implementation** (`.ail`-only, no TS): `tool_catalog.ail` (edit_decl_schema + tools()), `tool_runtime.ail` (Native routing in backend_for/_v2, dispatch branch, `run_edit_decl` handler mirroring `run_write_file` + `ailang ast-edit replace`). Reuses WriteFileResult/ToolErrorResult (no new variant → no match-ripple). Core type-check passes (`ailang check src/core/*.ail`).

**DRAFT — pending:** smoke test (motoko run using EditDecl on a multi-decl file → only the named decl changes) and a rig A/B (edit output-tokens + pass-rate vs the WriteFile baseline on a large-file edit task). Follow-ons: a dedicated EditDeclResult variant for cleaner trace rendering, and a prompts.ail tool-selection rule (EditDecl vs EditFile vs WriteFile).