### PR TITLE
arniwesth/mot-20-fix-broken-dev-docker

### DIFF
--- a/.agent/prs/mot-20-fix-broken-dev-docker.md
+++ b/.agent/prs/mot-20-fix-broken-dev-docker.md
@@ -1,0 +1,31 @@
+# Fix Devcontainer Prerequisite Installer
+
+Base branch: `origin/main`
+
+## Summary
+
+This branch fixes Docker/devcontainer builds that run
+`./scripts/install-prerequisites.sh`.
+
+The installer previously allowed Debian package installs to prompt through
+`tzdata`, which blocks noninteractive Docker builds. It could also fail in the
+DuckDB CLI install path because `DUCKDB_VERSION` was referenced without being
+defined under `set -u`.
+
+## Changes
+
+- Set Debian installer defaults to `DEBIAN_FRONTEND=noninteractive` and
+  `TZ=Etc/UTC` unless already provided.
+- Run all apt update/install calls in the script with the noninteractive Debian
+  environment.
+- Add `DUCKDB_VERSION="1.1.3"`.
+- Restore the DuckDB CLI installer for Linux and macOS.
+- Add DuckDB to the main install flow and final installer summary.
+- Add a session summary for this fix under `.agent/summaries/`.
+
+## Verification
+
+- `bash -n ./scripts/install-prerequisites.sh`
+- Checked that the DuckDB `v1.1.3` Linux amd64 release URL resolves on GitHub.
+
+Note: `shellcheck` was not installed in the environment, so it was not run.

--- a/.agent/summaries/2026-06-22-devcontainer-installer-prerequisites-fix.md
+++ b/.agent/summaries/2026-06-22-devcontainer-installer-prerequisites-fix.md
@@ -1,0 +1,68 @@
+# Devcontainer Installer Prerequisites Fix
+
+Date: 2026-06-22
+
+## Context
+
+The devcontainer Docker build was breaking when running `./scripts/install-prerequisites.sh`.
+
+Two failures were reported:
+
+- `tzdata` prompted for geographic area and city during apt package installation, which blocks Docker builds.
+- The installer reached the DuckDB CLI section and failed under `set -u` with `DUCKDB_VERSION: unbound variable`.
+
+## Investigation
+
+Checked:
+
+- `scripts/install-prerequisites.sh`
+- `.devcontainer/Dockerfile`
+- historical commits touching the installer
+
+Findings:
+
+- Current `scripts/install-prerequisites.sh` did not contain a DuckDB installer block, but a prior commit (`9ac9e03`) had one and defined `DUCKDB_VERSION="1.1.3"`.
+- The working tree already had `.devcontainer/Dockerfile` modified to comment out `RUN ./scripts/install-prerequisites.sh`; that existing local change was left untouched.
+- Debian apt installs were not consistently forcing `DEBIAN_FRONTEND=noninteractive`, allowing `tzdata` to prompt.
+
+## Changes Made
+
+Updated `scripts/install-prerequisites.sh`:
+
+- Added DuckDB to the dependency list.
+- Added `DUCKDB_VERSION="1.1.3"`.
+- Added `duckdb_ok`.
+- Restored `install_duckdb` using the official DuckDB GitHub release ZIPs:
+  - `amd64` maps to `duckdb_cli-linux-amd64.zip`
+  - `arm64` maps to `duckdb_cli-linux-aarch64.zip`
+- Added `install_duckdb` to the main install flow after Node.js.
+- Added DuckDB to the final summary output.
+- Exported Debian defaults in `configure_privilege`:
+  - `DEBIAN_FRONTEND=noninteractive`
+  - `TZ=Etc/UTC` unless already set
+- Updated all apt install/update calls in the script to run through:
+  - `env DEBIAN_FRONTEND=noninteractive TZ="${TZ:-Etc/UTC}"`
+
+## Verification
+
+Ran:
+
+```bash
+bash -n ./scripts/install-prerequisites.sh
+```
+
+Result: passed.
+
+Also checked the DuckDB `v1.1.3` amd64 release URL with `curl -fsSIL`; GitHub returned a valid redirect to the release asset.
+
+`shellcheck` was not installed in the environment, so it was not run.
+
+## Remaining Notes
+
+`.devcontainer/Dockerfile` still has the installer line commented out from a pre-existing local change:
+
+```dockerfile
+#RUN ./scripts/install-prerequisites.sh
+```
+
+The installer itself is now patched so that line can be restored when desired.

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -6,6 +6,7 @@
 #   - Go 1.22+
 #   - Bun 1.x
 #   - Node.js 18+ and npm
+#   - DuckDB CLI
 #   - Python data science packages for scratchpad cells (pandas, polars, numpy, SciPy, scikit-learn)
 #   - context-mode CLI
 #   - AILANG runtime (cloned from github.com/sunholo-data/ailang at pinned tag)
@@ -37,6 +38,7 @@ NODE_MIN_MAJOR=18
 OMNIGRAPH_MIN_VERSION="0.3.0"
 AILANG_REF="v0.24.2"
 AILANG_MIN_VERSION="0.24.2"
+DUCKDB_VERSION="1.1.3"
 INSTALL_OMNIGRAPH=0
 INSTALL_LEAN=0
 INSTALL_LEAN_MATHLIB=0
@@ -187,6 +189,9 @@ configure_privilege() {
     return
   fi
 
+  export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
+  export TZ="${TZ:-Etc/UTC}"
+
   if [[ "$(id -u)" -eq 0 ]]; then
     SUDO=()
     SUDO_E=()
@@ -234,6 +239,10 @@ npm_ok() {
   command -v npm &>/dev/null
 }
 
+duckdb_ok() {
+  command -v duckdb &>/dev/null
+}
+
 context_mode_ok() {
   if ! command -v context-mode &>/dev/null; then return 1; fi
   context-mode doctor &>/dev/null
@@ -263,7 +272,7 @@ ensure_user_local_bin_on_path() {
 install_apt_packages() {
   log_header "System packages (apt)"
   log_info "Updating package lists..."
-  "${SUDO[@]}" apt-get update -qq
+  "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive TZ="${TZ:-Etc/UTC}" apt-get update -qq
 
   local pkgs=(
     git
@@ -288,7 +297,7 @@ install_apt_packages() {
     log_ok "All system packages already installed"
   else
     log_info "Installing: ${missing[*]}"
-    "${SUDO[@]}" apt-get install -y -qq "${missing[@]}"
+    "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive TZ="${TZ:-Etc/UTC}" apt-get install -y -qq "${missing[@]}"
     log_ok "System packages installed"
   fi
 }
@@ -415,7 +424,7 @@ install_node() {
   else
     log_info "Installing Node.js 22.x via NodeSource..."
     curl -fsSL https://deb.nodesource.com/setup_22.x | "${SUDO_E[@]}" bash -
-    "${SUDO[@]}" apt-get install -y -qq nodejs
+    "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive TZ="${TZ:-Etc/UTC}" apt-get install -y -qq nodejs
   fi
 
   if ! node_version_ok; then
@@ -425,6 +434,50 @@ install_node() {
     die "Node.js install completed but npm is not on PATH."
   fi
   log_ok "Node.js $(node --version) and npm $(npm --version) installed"
+}
+
+# ---------------------------------------------------------------------------
+# DuckDB CLI
+# ---------------------------------------------------------------------------
+install_duckdb() {
+  log_header "DuckDB CLI"
+  if duckdb_ok; then
+    log_ok "duckdb already installed at $(command -v duckdb)"
+    return
+  fi
+
+  if [[ "$OS" == "macos" ]]; then
+    log_info "Installing duckdb via Homebrew..."
+    brew install duckdb
+  else
+    # DuckDB is not packaged in Debian/Ubuntu apt repos, so download the
+    # official CLI release binary for this architecture into ~/.local/bin.
+    ensure_user_local_bin_on_path
+    local ddb_arch
+    case "$ARCH" in
+      amd64) ddb_arch="amd64" ;;
+      arm64) ddb_arch="aarch64" ;;
+      *)     log_warn "No DuckDB CLI release for arch '$ARCH'. Install duckdb manually."; return ;;
+    esac
+    local url="https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-${ddb_arch}.zip"
+    local tmp
+    tmp="$(mktemp -d)"
+    log_info "Downloading DuckDB ${DUCKDB_VERSION} CLI (linux/${ddb_arch})..."
+    if ! curl -fsSL "$url" -o "${tmp}/duckdb.zip"; then
+      log_warn "Failed to download DuckDB CLI from ${url}. Install duckdb manually."
+      rm -rf "$tmp"; return
+    fi
+    unzip -o -q "${tmp}/duckdb.zip" -d "$tmp"
+    cp "${tmp}/duckdb" "$HOME/.local/bin/duckdb"
+    chmod +x "$HOME/.local/bin/duckdb"
+    rm -rf "$tmp"
+  fi
+
+  if duckdb_ok; then
+    log_ok "duckdb installed at $(command -v duckdb)"
+  else
+    log_warn "duckdb installation step finished but binary is not on PATH"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -544,7 +597,7 @@ install_omnigraph() {
     done
     if [[ ${#og_missing[@]} -gt 0 ]]; then
       log_info "Installing Omnigraph apt prerequisites: ${og_missing[*]}"
-      "${SUDO[@]}" apt-get install -y -qq "${og_missing[@]}"
+      "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive TZ="${TZ:-Etc/UTC}" apt-get install -y -qq "${og_missing[@]}"
     fi
   else
     for pkg in protobuf; do
@@ -609,6 +662,7 @@ print_summary() {
   echo "  Node.js: $(node --version 2>/dev/null || echo 'not found')"
   echo "  npm:     $(npm --version 2>/dev/null || echo 'not found')"
   echo "  ailang:  $(command -v ailang &>/dev/null && echo 'found' || echo 'not found')"
+  echo "  duckdb:  $(command -v duckdb &>/dev/null && echo 'found' || echo 'not found')"
   echo "  context-mode: $(command -v context-mode &>/dev/null && echo 'found' || echo 'not found')"
   echo "  omnigraph: $(command -v omnigraph &>/dev/null && echo 'found' || echo 'not found')"
   echo "  lean:    $(command -v lean &>/dev/null && echo 'found' || echo 'not found')"
@@ -637,6 +691,7 @@ main() {
   install_go
   install_bun
   install_node
+  install_duckdb
   if [[ "$OS" == "debian" ]]; then
     install_python_data_science_packages
   fi


### PR DESCRIPTION
# Fix Devcontainer Prerequisite Installer

Base branch: `origin/main`

## Summary

This branch fixes Docker/devcontainer builds that run
`./scripts/install-prerequisites.sh`.

The installer previously allowed Debian package installs to prompt through
`tzdata`, which blocks noninteractive Docker builds. It could also fail in the
DuckDB CLI install path because `DUCKDB_VERSION` was referenced without being
defined under `set -u`.

## Changes

- Set Debian installer defaults to `DEBIAN_FRONTEND=noninteractive` and
  `TZ=Etc/UTC` unless already provided.
- Run all apt update/install calls in the script with the noninteractive Debian
  environment.
- Add `DUCKDB_VERSION="1.1.3"`.
- Restore the DuckDB CLI installer for Linux and macOS.
- Add DuckDB to the main install flow and final installer summary.
- Add a session summary for this fix under `.agent/summaries/`.

## Verification

- `bash -n ./scripts/install-prerequisites.sh`
- Checked that the DuckDB `v1.1.3` Linux amd64 release URL resolves on GitHub.

Note: `shellcheck` was not installed in the environment, so it was not run.