### PR TITLE
arniwesth/mot 21 fix local model routing

### DIFF
--- a/.agent/prs/mot-21-fix-local-model-routing.md
+++ b/.agent/prs/mot-21-fix-local-model-routing.md
@@ -4,61 +4,33 @@ Base branch: `origin/main`
 
 ## Summary
 
-This branch fixes Motoko model resolution so interactive TUI runs and headless
-runs use the same selected model and route it through the intended provider.
+This branch fixes Motoko model routing so local OpenAI-compatible profiles, direct provider models, OpenRouter models, and Ollama models are routed through the intended provider while preserving the selected model string for UI state, context accounting, and model switching.
 
-The critical fix is that Motoko no longer passes direct-provider model ids such
-as `openai/deepseek-v4-flash`, `openai/gpt-4o`, `anthropic/...`, or `google/...`
-to AILANG's `--ai` provider guessing unchanged. AILANG treats those
-`vendor/model` strings as OpenRouter ids, so `PROFILE=local make run` could
-silently route a local OpenAI-compatible profile through OpenRouter. The TUI
-launcher now normalizes provider-selection ids separately from the model id sent
-to `stepWithStream`.
-
-Local OpenAI-compatible profiles now force AILANG's OpenAI provider selection
-while preserving the real local model id for the provider request. Explicit
-OpenRouter ids still use `openrouter/...`, and Ollama ids still use
-`ollama/...`.
+The main bug was that Motoko used provider-like model IDs such as `openai/deepseek-v4-flash`, `openai/gpt-4o`, `anthropic/...`, and `google/...` in multiple places with different meanings. AILANG's provider guessing treats many `vendor/model` strings as OpenRouter IDs, so local or direct-provider runs could silently route through OpenRouter. The TUI now normalizes the model used for AILANG provider selection separately from the model sent to the provider API call.
 
 ## Changes
 
-- Add shared runtime model resolution for both TUI and headless startup:
-  `MODEL` environment variable, then profile `agent.model`, then the default
-  runtime model.
-- Keep `process.env.MODEL` synchronized with the resolved runtime model so
-  env-server, scratchpad, subagents, and the runtime process agree.
-- Add TUI-side provider-selection normalization:
-  - Local OpenAI-compatible endpoints use an OpenAI-shaped `--ai` selector.
-  - Direct `openai/`, `anthropic/`, and `google/` profile ids are stripped
-    before AILANG provider guessing.
-  - Explicit `openrouter/...`, `openrouter/auto`, and `ollama/...` ids are
-    preserved.
-- Normalize the provider API model at the `stepWithStream` boundary while
-  keeping the user-facing/profile model id intact for display, context
-  accounting, and model switching.
-- Fix blank environment overrides such as `OPENAI_BASE_URL=` so they no longer
-  mask profile-configured local endpoint values.
-- Update the local profile and local `compaction_ai` config to use
-  `openai/deepseek-v4-flash` instead of OpenRouter model ids.
-- Build and use the repo-local `ailang/bin/ailang` from `make run`, so branch
-  behavior does not depend on an older globally installed AILANG binary.
-- Make Makefile AILANG checks and package sync use the same repo-local binary,
-  and make `PROFILE=local make run` verify the local profile extension set.
-- Suppress expected local-runtime warning noise in the TUI:
-  - AILANG stdlib version mismatch warnings from dirty local builds.
-  - Informational cache-hint warnings for providers that cannot honor explicit
-    cache breakpoints.
-  - Duplicate `Warning: Warning:` prefixes.
-- Suppress the Motoko banner/header in headless and JSONL modes.
-- Route runtime stderr through structured warning events instead of letting it
-  spill into the TUI input line.
-- Move model picker/discovery data and concrete per-model context limits into
-  `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` as an override.
-- Replace hardcoded concrete context-window entries in core AILANG with catalog
-  lookups plus broad provider-family fallbacks.
-- Document model identifier rules in `README.md`, including local
-  OpenAI-compatible models, direct Google/Vertex `gemini-*` ids, OpenRouter
-  `vendor/model` ids, and Ollama `ollama/<model>` ids.
+- Add shared runtime model resolution for TUI and headless startup:
+  `MODEL` env var, then profile `agent.model`, then `anthropic/claude-sonnet-4-6`.
+- Keep `process.env.MODEL` synchronized with the resolved runtime model so helper paths such as env-server, scratchpad, subagents, and runtime restarts agree on the active model.
+- Add TUI provider-selection normalization:
+  - Local OpenAI-compatible endpoints force AILANG's OpenAI provider selection.
+  - Direct `openai/`, `anthropic/`, and `google/` Motoko routing prefixes are stripped before AILANG provider guessing.
+  - Explicit `openrouter/...`, `openrouter/auto`, and `ollama/...` model IDs are preserved.
+- Normalize provider API model IDs at the `stepWithStream` boundary:
+  - `openrouter/<vendor>/<model>` sends `<vendor>/<model>` to OpenRouter.
+  - `openrouter/auto` stays intact.
+  - Direct `openai/`, `anthropic/`, and `google/` prefixes are stripped for the provider request.
+  - Ollama routing IDs are preserved.
+- Fix blank environment overrides such as `OPENAI_BASE_URL=` so they no longer mask profile-configured local endpoint values.
+- Update the local profile and local compaction config to use `openai/deepseek-v4-flash`.
+- Move model picker data, OpenRouter fallback models, and concrete context limits into `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` as an override.
+- Replace hardcoded concrete context-window entries in core AILANG with catalog lookups plus broad provider-family fallbacks.
+- Use the repo-local `ailang/bin/ailang` from Make targets and package sync so local runs do not depend on an older globally installed AILANG binary.
+- Make `PROFILE=local make run` verify the selected local profile extension set before startup.
+- Suppress expected local-runtime warning noise in the TUI and route runtime stderr through structured warning events instead of spilling raw stderr into the input line.
+- Suppress terminal title/banner output in headless and JSONL modes.
+- Document model identifier rules in `README.md`, including local OpenAI-compatible models, direct Google/Vertex `gemini-*` IDs, OpenRouter pinned/routing IDs, and Ollama IDs.
 
 ## Verification
 
@@ -69,9 +41,6 @@ OpenRouter ids still use `openrouter/...`, and Ollama ids still use
 - `bun test src/tui/src/runtime-process.stream-protocol.test.ts`
 - `bun test src/tui/src/models.test.ts`
 - `bun run --cwd src/tui build`
-- Headless `MOTOKO_CONFIG=local` smoke succeeded with an intentionally bogus
-  OpenRouter key.
-- `PROFILE=local make run` smoke succeeded and verified the local profile
-  extension set before startup.
-- Local endpoint probe confirmed the remaining timeout error is TCP
-  connectivity to `http://100.79.48.75:8000`, not OpenRouter routing.
+- Headless `MOTOKO_CONFIG=local` smoke succeeded with an intentionally bogus OpenRouter key.
+- `PROFILE=local make run` smoke succeeded and verified the local profile extension set before startup.
+- Local endpoint probe confirmed the remaining timeout error is TCP connectivity to `http://...:8000`, not OpenRouter routing.

--- a/.agent/prs/mot-21-fix-local-model-routing.md
+++ b/.agent/prs/mot-21-fix-local-model-routing.md
@@ -4,43 +4,78 @@ Base branch: `origin/main`
 
 ## Summary
 
-This branch fixes Motoko model routing so local OpenAI-compatible profiles, direct provider models, OpenRouter models, and Ollama models are routed through the intended provider while preserving the selected model string for UI state, context accounting, and model switching.
+This branch fixes Motoko model routing so local OpenAI-compatible models are
+not accidentally sent through OpenRouter, while preserving the selected Motoko
+model string for UI state, profile state, context telemetry, and follow-up
+turns.
 
-The main bug was that Motoko used provider-like model IDs such as `openai/deepseek-v4-flash`, `openai/gpt-4o`, `anthropic/...`, and `google/...` in multiple places with different meanings. AILANG's provider guessing treats many `vendor/model` strings as OpenRouter IDs, so local or direct-provider runs could silently route through OpenRouter. The TUI now normalizes the model used for AILANG provider selection separately from the model sent to the provider API call.
+The previous routing path passed Motoko's UI/profile identifiers directly to
+AILANG provider selection and then partially stripped prefixes before
+`std/ai.step()`. That made local models such as
+`openai/deepseek-v4-flash` or `openai/google/gemma-4-26B-A4B-it` ambiguous:
+the prefix was useful to Motoko, but AILANG could interpret slashful vendor
+strings as OpenRouter routing ids.
 
 ## Changes
 
-- Add shared runtime model resolution for TUI and headless startup:
-  `MODEL` env var, then profile `agent.model`, then `anthropic/claude-sonnet-4-6`.
-- Keep `process.env.MODEL` synchronized with the resolved runtime model so helper paths such as env-server, scratchpad, subagents, and runtime restarts agree on the active model.
-- Add TUI provider-selection normalization:
-  - Local OpenAI-compatible endpoints force AILANG's OpenAI provider selection.
-  - Direct `openai/`, `anthropic/`, and `google/` Motoko routing prefixes are stripped before AILANG provider guessing.
-  - Explicit `openrouter/...`, `openrouter/auto`, and `ollama/...` model IDs are preserved.
-- Normalize provider API model IDs at the `stepWithStream` boundary:
-  - `openrouter/<vendor>/<model>` sends `<vendor>/<model>` to OpenRouter.
-  - `openrouter/auto` stays intact.
-  - Direct `openai/`, `anthropic/`, and `google/` prefixes are stripped for the provider request.
-  - Ollama routing IDs are preserved.
-- Fix blank environment overrides such as `OPENAI_BASE_URL=` so they no longer mask profile-configured local endpoint values.
-- Update the local profile and local compaction config to use `openai/deepseek-v4-flash`.
-- Move model picker data, OpenRouter fallback models, and concrete context limits into `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` as an override.
-- Replace hardcoded concrete context-window entries in core AILANG with catalog lookups plus broad provider-family fallbacks.
-- Use the repo-local `ailang/bin/ailang` from Make targets and package sync so local runs do not depend on an older globally installed AILANG binary.
-- Make `PROFILE=local make run` verify the selected local profile extension set before startup.
-- Suppress expected local-runtime warning noise in the TUI and route runtime stderr through structured warning events instead of spilling raw stderr into the input line.
-- Suppress terminal title/banner output in headless and JSONL modes.
-- Document model identifier rules in `README.md`, including local OpenAI-compatible models, direct Google/Vertex `gemini-*` IDs, OpenRouter pinned/routing IDs, and Ollama IDs.
+- Add a two-stage model routing split:
+  - the TUI launcher maps Motoko model ids to an AILANG `--ai` provider
+    selector with `providerSelectionModel`
+  - the AILANG runtime maps Motoko model ids to provider API model ids with
+    `provider_api_model`
+- Route local OpenAI-compatible runs through AILANG's OpenAI provider when
+  `OPENAI_BASE_URL` is set, while still sending the actual local model id to
+  the provider request.
+- Preserve explicit OpenRouter routing ids, including `openrouter/auto`, and
+  strip only the outer `openrouter/` prefix for pinned OpenRouter
+  vendor/model ids before the provider API call.
+- Strip Motoko direct-provider prefixes for direct OpenAI, Anthropic, and
+  Google model requests before AILANG provider guessing and before
+  `std/ai.step()`.
+- Move the static model picker catalog and known context windows into
+  `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` support for custom
+  catalogs.
+- Update context usage, budget planning, extension context, and structural
+  compaction to read catalog-backed context limits, while keeping broad
+  provider-family fallbacks for unknown models.
+- Resolve the runtime model consistently as:
+  `MODEL` env var > profile `agent.model` > `anthropic/claude-sonnet-4-6`,
+  then publish the resolved value back to `process.env.MODEL` so helper paths
+  observe the same model.
+- Update the local profile defaults to use `openai/deepseek-v4-flash` against
+  the configured local OpenAI-compatible endpoint.
+- Document Motoko model identifier semantics in the README, including the
+  difference between direct Gemini ids and OpenRouter `google/...` vendor ids.
+- Capture AILANG runtime stderr as structured warning events, suppressing known
+  local informational noise such as stdlib version mismatch and cache-hint
+  warnings.
+- Add focused tests for runtime model resolution, catalog loading, OpenRouter
+  fallback models, local OpenAI model discovery, provider selection, warning
+  normalization, and AILANG-side provider API model conversion.
+
+## User Impact
+
+- Local OpenAI-compatible profiles can select local model ids with the
+  `openai/` Motoko routing prefix without leaking those requests to
+  OpenRouter.
+- Slashful local model ids are preserved after the `openai/` routing prefix is
+  removed, so ids like `google/gemma-4-26B-A4B-it` still reach the local
+  endpoint correctly.
+- Direct Gemini / Vertex usage is clearer: use bare `gemini-*` ids for direct
+  Google routing, and `openrouter/google/...` for OpenRouter.
+- The `/model` picker can be updated through JSON catalog data instead of
+  TypeScript edits.
+- Context counters and compaction use the same catalog-backed model limits as
+  the TUI model catalog.
 
 ## Verification
 
-- `make build`
-- `MOTOKO_CONFIG=local make check_core`
-- `AILANG_STDLIB_PATH=/workspaces/motoko_agent/ailang/std ./ailang/bin/ailang test src/core/agent_loop_v2.ail`
-- `cd ailang && go test ./cmd/ailang -run 'OpenAI.*(Local|Custom|KeyRelaxation|UsesCustomBaseURL)'`
-- `bun test src/tui/src/runtime-process.stream-protocol.test.ts`
-- `bun test src/tui/src/models.test.ts`
-- `bun run --cwd src/tui build`
-- Headless `MOTOKO_CONFIG=local` smoke succeeded with an intentionally bogus OpenRouter key.
-- `PROFILE=local make run` smoke succeeded and verified the local profile extension set before startup.
-- Local endpoint probe confirmed the remaining timeout error is TCP connectivity to `http://...:8000`, not OpenRouter routing.
+- `make -n build`
+  - Confirms build, sync, lock, extension boot, and core check commands use
+    upstream `ailang` from PATH.
+- `cd src/tui && bun run build`
+  - Passes.
+- `cd src/tui && bun run test -- src/models.test.ts src/runtime-process.stream-protocol.test.ts`
+  - Does not reach test execution in this environment. Jest fails during
+    startup with `TypeError: Attempted to assign to readonly property` from
+    `jest-runtime` / `stack-utils`, before any test cases run.

--- a/.agent/prs/mot-21-fix-local-model-routing.md
+++ b/.agent/prs/mot-21-fix-local-model-routing.md
@@ -4,66 +4,74 @@ Base branch: `origin/main`
 
 ## Summary
 
-This branch fixes local OpenAI-compatible model routing by separating Motoko's
-UI/profile model identifiers from the provider API model id sent to
-`stepWithStream`.
+This branch fixes Motoko model resolution so interactive TUI runs and headless
+runs use the same selected model and route it through the intended provider.
 
-Previously `PROFILE=local` could pass a model like
-`openai/deepseek-v4-flash` all the way into the upstream request body, causing
-local servers to reject it as an invalid model id. The runtime now keeps the
-prefixed model for display, context accounting, and provider routing, but
-normalizes the provider API model id only at the AI call boundary.
+The critical fix is that Motoko no longer passes direct-provider model ids such
+as `openai/deepseek-v4-flash`, `openai/gpt-4o`, `anthropic/...`, or `google/...`
+to AILANG's `--ai` provider guessing unchanged. AILANG treats those
+`vendor/model` strings as OpenRouter ids, so `PROFILE=local make run` could
+silently route a local OpenAI-compatible profile through OpenRouter. The TUI
+launcher now normalizes provider-selection ids separately from the model id sent
+to `stepWithStream`.
 
-It also centralizes runtime model resolution so TUI and headless runs choose the
-model with the same precedence: `MODEL` environment variable, then profile
-`agent.model`, then the default runtime model.
+Local OpenAI-compatible profiles now force AILANG's OpenAI provider selection
+while preserving the real local model id for the provider request. Explicit
+OpenRouter ids still use `openrouter/...`, and Ollama ids still use
+`ollama/...`.
 
 ## Changes
 
-- Switch the local profile model from `openai/google/gemma-4-26B-A4B-it` to
-  `openai/deepseek-v4-flash`.
-- Replace the old OpenRouter-only prefix stripping with `provider_api_model`.
-- Strip the explicit `openrouter/` Motoko routing prefix only for pinned
-  vendor/model ids before `stepWithStream`, preserving OpenRouter vendor/model
-  ids such as `anthropic/claude-sonnet-4-6`.
-- Preserve `openrouter/auto`, which AILANG documents and tests as the
-  OpenRouter routing-policy model.
-- Strip `openai/` only when `OPENAI_BASE_URL` is set, where
-  `openai/<local-id>` is local OpenAI-compatible routing syntax rather than an
-  OpenRouter vendor/model id.
-- Preserve `ollama/...` model ids so AILANG can route them to the native Ollama
-  provider, which strips the Ollama prefix internally.
-- Document model identifier rules in `README.md`, including the direct
-  Google/Vertex `gemini-*` form versus the OpenRouter `google/...` vendor/model
-  form.
-- Move the TUI baseline model catalog and OpenRouter fallback catalog to
+- Add shared runtime model resolution for both TUI and headless startup:
+  `MODEL` environment variable, then profile `agent.model`, then the default
+  runtime model.
+- Keep `process.env.MODEL` synchronized with the resolved runtime model so
+  env-server, scratchpad, subagents, and the runtime process agree.
+- Add TUI-side provider-selection normalization:
+  - Local OpenAI-compatible endpoints use an OpenAI-shaped `--ai` selector.
+  - Direct `openai/`, `anthropic/`, and `google/` profile ids are stripped
+    before AILANG provider guessing.
+  - Explicit `openrouter/...`, `openrouter/auto`, and `ollama/...` ids are
+    preserved.
+- Normalize the provider API model at the `stepWithStream` boundary while
+  keeping the user-facing/profile model id intact for display, context
+  accounting, and model switching.
+- Fix blank environment overrides such as `OPENAI_BASE_URL=` so they no longer
+  mask profile-configured local endpoint values.
+- Update the local profile and local `compaction_ai` config to use
+  `openai/deepseek-v4-flash` instead of OpenRouter model ids.
+- Build and use the repo-local `ailang/bin/ailang` from `make run`, so branch
+  behavior does not depend on an older globally installed AILANG binary.
+- Make Makefile AILANG checks and package sync use the same repo-local binary,
+  and make `PROFILE=local make run` verify the local profile extension set.
+- Suppress expected local-runtime warning noise in the TUI:
+  - AILANG stdlib version mismatch warnings from dirty local builds.
+  - Informational cache-hint warnings for providers that cannot honor explicit
+    cache breakpoints.
+  - Duplicate `Warning: Warning:` prefixes.
+- Suppress the Motoko banner/header in headless and JSONL modes.
+- Route runtime stderr through structured warning events instead of letting it
+  spill into the TUI input line.
+- Move model picker/discovery data and concrete per-model context limits into
   `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` as an override.
-- Move concrete per-model context windows to `.motoko/model-catalog.json`
-  under `context_limits`; core AILANG now keeps only broad provider-family
-  fallback limits.
-- Keep `.motoko/model-catalog.json` out of runtime model selection; it feeds
-  picker/discovery suggestions and known context-window metadata.
-- Add a shared `resolveRuntimeModel` helper and use it before both interactive
-  and headless runtime startup.
-- Publish the resolved model back to `process.env.MODEL` so env-server,
-  scratchpad, subagents, and runtime process args agree on the same model.
-- Suppress the Motoko banner/header in headless and JSONL modes so those bytes
-  are not written into headless output.
-- Route runtime stderr through warning events instead of inheriting it into the
-  TUI prompt line.
-- Update the configured direct Google/Vertex models to use bare `gemini-*` ids.
-- Add regression tests for OpenRouter pinned models, `openrouter/auto`, local
-  OpenAI-compatible models, vendor/model ids, Ollama model id normalization,
-  shared runtime model resolution, model catalog loading, context-limit catalog
-  parsing, direct Gemini model picker entries, and headless local/OpenRouter
-  smoke paths.
+- Replace hardcoded concrete context-window entries in core AILANG with catalog
+  lookups plus broad provider-family fallbacks.
+- Document model identifier rules in `README.md`, including local
+  OpenAI-compatible models, direct Google/Vertex `gemini-*` ids, OpenRouter
+  `vendor/model` ids, and Ollama `ollama/<model>` ids.
 
 ## Verification
 
-- `ailang check src/core/agent_loop_v2.ail`
-- `ailang test src/core/agent_loop_v2.ail`
-- `ailang check src/core/context_usage.ail`
+- `make build`
+- `MOTOKO_CONFIG=local make check_core`
+- `AILANG_STDLIB_PATH=/workspaces/motoko_agent/ailang/std ./ailang/bin/ailang test src/core/agent_loop_v2.ail`
+- `cd ailang && go test ./cmd/ailang -run 'OpenAI.*(Local|Custom|KeyRelaxation|UsesCustomBaseURL)'`
+- `bun test src/tui/src/runtime-process.stream-protocol.test.ts`
 - `bun test src/tui/src/models.test.ts`
 - `bun run --cwd src/tui build`
-- Headless `MOTOKO_CONFIG=local` smoke returned `ok` without the invalid model
-  id error.
+- Headless `MOTOKO_CONFIG=local` smoke succeeded with an intentionally bogus
+  OpenRouter key.
+- `PROFILE=local make run` smoke succeeded and verified the local profile
+  extension set before startup.
+- Local endpoint probe confirmed the remaining timeout error is TCP
+  connectivity to `http://100.79.48.75:8000`, not OpenRouter routing.

--- a/.agent/prs/mot-21-fix-local-model-routing.md
+++ b/.agent/prs/mot-21-fix-local-model-routing.md
@@ -11,24 +11,51 @@ UI/profile model identifiers from the provider API model id sent to
 Previously `PROFILE=local` could pass a model like
 `openai/deepseek-v4-flash` all the way into the upstream request body, causing
 local servers to reject it as an invalid model id. The runtime now keeps the
-prefixed model for display, context accounting, and provider routing, but strips
-provider routing prefixes only at the AI call boundary.
+prefixed model for display, context accounting, and provider routing, but
+normalizes the provider API model id only at the AI call boundary.
+
+It also centralizes runtime model resolution so TUI and headless runs choose the
+model with the same precedence: `MODEL` environment variable, then profile
+`agent.model`, then the default runtime model.
 
 ## Changes
 
 - Switch the local profile model from `openai/google/gemma-4-26B-A4B-it` to
   `openai/deepseek-v4-flash`.
 - Replace the old OpenRouter-only prefix stripping with `provider_api_model`.
-- Strip `openrouter/`, `openai/`, `google/`, and `anthropic/` before
-  `stepWithStream` receives the model id.
+- Strip the explicit `openrouter/` Motoko routing prefix only for pinned
+  vendor/model ids before `stepWithStream`, preserving OpenRouter vendor/model
+  ids such as `anthropic/claude-sonnet-4-6`.
+- Preserve `openrouter/auto`, which AILANG documents and tests as the
+  OpenRouter routing-policy model.
+- Strip `openai/` only when `OPENAI_BASE_URL` is set, where
+  `openai/<local-id>` is local OpenAI-compatible routing syntax rather than an
+  OpenRouter vendor/model id.
 - Preserve `ollama/...` model ids so AILANG can route them to the native Ollama
   provider, which strips the Ollama prefix internally.
-- Add regression tests for OpenRouter, local OpenAI-compatible, Google, and
-  Ollama model id normalization.
+- Document model identifier rules in `README.md`, including the direct
+  Google/Vertex `gemini-*` form versus the OpenRouter `google/...` vendor/model
+  form.
+- Move the TUI baseline model catalog and OpenRouter fallback catalog to
+  `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` as an override.
+- Keep `.motoko/model-catalog.json` scoped to picker/discovery suggestions; it
+  does not choose the runtime model.
+- Add a shared `resolveRuntimeModel` helper and use it before both interactive
+  and headless runtime startup.
+- Publish the resolved model back to `process.env.MODEL` so env-server,
+  scratchpad, subagents, and runtime process args agree on the same model.
+- Update the configured direct Google/Vertex models to use bare `gemini-*` ids.
+- Add regression tests for OpenRouter pinned models, `openrouter/auto`, local
+  OpenAI-compatible models, vendor/model ids, Ollama model id normalization,
+  shared runtime model resolution, model catalog loading, and direct Gemini
+  model picker entries.
 
 ## Verification
 
 - `ailang check src/core/agent_loop_v2.ail`
 - `ailang test src/core/agent_loop_v2.ail`
+- `ailang check src/core/context_usage.ail`
+- `bun test src/tui/src/models.test.ts`
+- `bun run --cwd src/tui build`
 - Headless `MOTOKO_CONFIG=local` smoke returned `ok` without the invalid model
   id error.

--- a/.agent/prs/mot-21-fix-local-model-routing.md
+++ b/.agent/prs/mot-21-fix-local-model-routing.md
@@ -36,8 +36,9 @@ strings as OpenRouter routing ids.
   `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` support for custom
   catalogs.
 - Update context usage, budget planning, extension context, and structural
-  compaction to read catalog-backed context limits, while keeping broad
-  provider-family fallbacks for unknown models.
+  compaction to read catalog-backed context limits. Unknown or uncatalogued
+  models have no known limit, so compaction is skipped rather than guessed from
+  provider-family prefixes.
 - Resolve the runtime model consistently as:
   `MODEL` env var > profile `agent.model` > `anthropic/claude-sonnet-4-6`,
   then publish the resolved value back to `process.env.MODEL` so helper paths
@@ -73,6 +74,20 @@ strings as OpenRouter routing ids.
 - `make -n build`
   - Confirms build, sync, lock, extension boot, and core check commands use
     upstream `ailang` from PATH.
+- `ailang check src/core/context_usage.ail`
+  - Passes.
+- `ailang test src/core/context_usage.ail`
+  - Passes: 11 tests.
+- `ailang check scripts/smoke_catalog_compaction.ail`
+  - Passes.
+- `ailang run --caps IO,FS,Env --entry main scripts/smoke_catalog_compaction.ail`
+  - Passes and confirms:
+    - `catalog_context_limit_for("test/tiny")` reads the checked-in catalog
+      limit of `100`.
+    - `compact_step_with_limit` reports `compaction_exhausted` when that
+      catalog limit is exceeded by non-elidable history.
+    - uncatalogued provider-prefixed models resolve to `0` instead of a
+      guessed provider-family limit.
 - `cd src/tui && bun run build`
   - Passes.
 - `cd src/tui && bun run test -- src/models.test.ts src/runtime-process.stream-protocol.test.ts`

--- a/.agent/prs/mot-21-fix-local-model-routing.md
+++ b/.agent/prs/mot-21-fix-local-model-routing.md
@@ -38,17 +38,25 @@ model with the same precedence: `MODEL` environment variable, then profile
   form.
 - Move the TUI baseline model catalog and OpenRouter fallback catalog to
   `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` as an override.
-- Keep `.motoko/model-catalog.json` scoped to picker/discovery suggestions; it
-  does not choose the runtime model.
+- Move concrete per-model context windows to `.motoko/model-catalog.json`
+  under `context_limits`; core AILANG now keeps only broad provider-family
+  fallback limits.
+- Keep `.motoko/model-catalog.json` out of runtime model selection; it feeds
+  picker/discovery suggestions and known context-window metadata.
 - Add a shared `resolveRuntimeModel` helper and use it before both interactive
   and headless runtime startup.
 - Publish the resolved model back to `process.env.MODEL` so env-server,
   scratchpad, subagents, and runtime process args agree on the same model.
+- Suppress the Motoko banner/header in headless and JSONL modes so those bytes
+  are not written into headless output.
+- Route runtime stderr through warning events instead of inheriting it into the
+  TUI prompt line.
 - Update the configured direct Google/Vertex models to use bare `gemini-*` ids.
 - Add regression tests for OpenRouter pinned models, `openrouter/auto`, local
   OpenAI-compatible models, vendor/model ids, Ollama model id normalization,
-  shared runtime model resolution, model catalog loading, and direct Gemini
-  model picker entries.
+  shared runtime model resolution, model catalog loading, context-limit catalog
+  parsing, direct Gemini model picker entries, and headless local/OpenRouter
+  smoke paths.
 
 ## Verification
 

--- a/.agent/prs/mot-21-fix-local-model-routing.md
+++ b/.agent/prs/mot-21-fix-local-model-routing.md
@@ -35,6 +35,9 @@ strings as OpenRouter routing ids.
 - Move the static model picker catalog and known context windows into
   `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` support for custom
   catalogs.
+- Preserve newer model context windows, such as
+  `ollama/qwen3.6:35b-a3b-mxfp8`, as catalog entries rather than hardcoded
+  AILANG branches.
 - Update context usage, budget planning, extension context, and structural
   compaction to read catalog-backed context limits. Unknown or uncatalogued
   models have no known limit, so compaction is skipped rather than guessed from
@@ -78,6 +81,10 @@ strings as OpenRouter routing ids.
   - Passes.
 - `ailang test src/core/context_usage.ail`
   - Passes: 11 tests.
+- `jq empty .motoko/model-catalog.json`
+  - Passes.
+- `jq -e '.context_limits["ollama/qwen3.6:35b-a3b-mxfp8"] == 262144' .motoko/model-catalog.json`
+  - Passes.
 - `ailang check scripts/smoke_catalog_compaction.ail`
   - Passes.
 - `ailang run --caps IO,FS,Env --entry main scripts/smoke_catalog_compaction.ail`

--- a/.agent/prs/mot-21-fix-local-model-routing.md
+++ b/.agent/prs/mot-21-fix-local-model-routing.md
@@ -1,0 +1,34 @@
+# Fix Local Model Routing
+
+Base branch: `origin/main`
+
+## Summary
+
+This branch fixes local OpenAI-compatible model routing by separating Motoko's
+UI/profile model identifiers from the provider API model id sent to
+`stepWithStream`.
+
+Previously `PROFILE=local` could pass a model like
+`openai/deepseek-v4-flash` all the way into the upstream request body, causing
+local servers to reject it as an invalid model id. The runtime now keeps the
+prefixed model for display, context accounting, and provider routing, but strips
+provider routing prefixes only at the AI call boundary.
+
+## Changes
+
+- Switch the local profile model from `openai/google/gemma-4-26B-A4B-it` to
+  `openai/deepseek-v4-flash`.
+- Replace the old OpenRouter-only prefix stripping with `provider_api_model`.
+- Strip `openrouter/`, `openai/`, `google/`, and `anthropic/` before
+  `stepWithStream` receives the model id.
+- Preserve `ollama/...` model ids so AILANG can route them to the native Ollama
+  provider, which strips the Ollama prefix internally.
+- Add regression tests for OpenRouter, local OpenAI-compatible, Google, and
+  Ollama model id normalization.
+
+## Verification
+
+- `ailang check src/core/agent_loop_v2.ail`
+- `ailang test src/core/agent_loop_v2.ail`
+- Headless `MOTOKO_CONFIG=local` smoke returned `ok` without the invalid model
+  id error.

--- a/.agent/summaries/2026-06-22-local-model-routing-fix.md
+++ b/.agent/summaries/2026-06-22-local-model-routing-fix.md
@@ -33,8 +33,11 @@ server received `openai/deepseek-v4-flash` instead of the API model id
   vendor/model form.
 - Move the TUI baseline model catalog and OpenRouter fallback catalog to
   `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` as an override.
-- Keep `.motoko/model-catalog.json` as picker/discovery configuration only;
-  runtime selection is resolved separately.
+- Move concrete per-model context windows to `.motoko/model-catalog.json`
+  under `context_limits`; core AILANG now keeps only broad provider-family
+  fallback limits.
+- Keep `.motoko/model-catalog.json` out of runtime model selection; it feeds
+  picker/discovery suggestions and known context-window metadata.
 - Add shared runtime model resolution for TUI and headless runs with precedence
   `MODEL` environment variable, then profile `agent.model`, then the default
   runtime model.
@@ -42,13 +45,17 @@ server received `openai/deepseek-v4-flash` instead of the API model id
   startup so env-server, scratchpad, subagents, and `RuntimeProcess` observe the
   same model.
 - Update the configured direct Google/Vertex models to use bare `gemini-*` ids.
-- Add direct Gemini context-window entries for context accounting.
+- Suppress the Motoko banner/header in headless and JSONL modes so headless
+  output stays machine-readable.
+- Route runtime stderr through warning events instead of inheriting it into the
+  TUI prompt line.
 - Kept the user-facing/profile model id intact for UI display, context
   accounting, and conversation model switching.
 - Added regression tests for OpenRouter pinned models, `openrouter/auto`, local
   OpenAI-compatible models with and without slashful ids, OpenRouter
   vendor/model ids, Ollama, shared runtime model resolution, model catalog
-  loading, and direct Gemini picker entries.
+  loading, context-limit catalog parsing, direct Gemini picker entries, and
+  headless local/OpenRouter smoke paths.
 - Wrote PR notes to `.agent/prs/mot-21-fix-local-model-routing.md`.
 
 ## Verification

--- a/.agent/summaries/2026-06-22-local-model-routing-fix.md
+++ b/.agent/summaries/2026-06-22-local-model-routing-fix.md
@@ -1,0 +1,48 @@
+# Local Model Routing Fix
+
+## Context
+
+`PROFILE=local make run` failed on the first model call with:
+
+```text
+openai/deepseek-v4-flash is not a valid model ID
+```
+
+The local profile used `openai/deepseek-v4-flash` as Motoko's routing/UI model
+identifier and pointed `openai_base_url` at a local OpenAI-compatible endpoint.
+Motoko passed that same prefixed identifier into `stepWithStream`, so the local
+server received `openai/deepseek-v4-flash` instead of the API model id
+`deepseek-v4-flash`.
+
+## Changes
+
+- Added `provider_api_model` in `src/core/agent_loop_v2.ail`.
+- Normalize provider-prefixed model ids only at the `stepWithStream` call
+  boundary.
+- Strip `openrouter/`, `openai/`, `google/`, and `anthropic/` before provider
+  API calls.
+- Keep `ollama/...` unchanged in Motoko so AILANG can route it to the native
+  Ollama provider, which strips the Ollama prefix internally.
+- Kept the user-facing/profile model id intact for UI display, context
+  accounting, and conversation model switching.
+- Added regression tests for OpenRouter, local OpenAI-compatible models with
+  and without slashful ids, Google, and Ollama.
+- Wrote PR notes to `.agent/prs/mot-21-fix-local-model-routing.md`.
+
+## Verification
+
+- `ailang check src/core/agent_loop_v2.ail`
+- `ailang test src/core/agent_loop_v2.ail`
+- Headless local smoke:
+
+```bash
+MOTOKO_CONFIG=local TASK='Reply exactly: ok' MOTOKO_HEADLESS=1 bun src/tui/src/index.ts
+```
+
+The smoke completed and returned `ok` without the invalid model id error.
+
+## Notes
+
+The AILANG MCP server is configured in `.mcp.json`, but no MCP resources were
+available in this Codex session. Local AILANG docs were consulted via the
+vendored `ailang/std` path instead.

--- a/.agent/summaries/2026-06-22-local-model-routing-fix.md
+++ b/.agent/summaries/2026-06-22-local-model-routing-fix.md
@@ -17,22 +17,47 @@ server received `openai/deepseek-v4-flash` instead of the API model id
 ## Changes
 
 - Added `provider_api_model` in `src/core/agent_loop_v2.ail`.
-- Normalize provider-prefixed model ids only at the `stepWithStream` call
-  boundary.
-- Strip `openrouter/`, `openai/`, `google/`, and `anthropic/` before provider
-  API calls.
+- Normalize provider API model ids only at the `stepWithStream` call boundary.
+- Strip the explicit `openrouter/` Motoko routing prefix only for pinned
+  vendor/model ids while preserving OpenRouter vendor/model ids such as
+  `anthropic/claude-sonnet-4-6`.
+- Preserve `openrouter/auto`, which the AILANG MCP docs and AILANG OpenRouter
+  tests use as the routing-policy model.
+- Strip `openai/` only when `OPENAI_BASE_URL` is set, where
+  `openai/<local-id>` is local OpenAI-compatible routing syntax rather than an
+  OpenRouter vendor/model id.
 - Keep `ollama/...` unchanged in Motoko so AILANG can route it to the native
   Ollama provider, which strips the Ollama prefix internally.
+- Document the model identifier matrix in `README.md`, including that direct
+  Google/Vertex uses bare `gemini-*` ids while `google/...` is an OpenRouter
+  vendor/model form.
+- Move the TUI baseline model catalog and OpenRouter fallback catalog to
+  `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` as an override.
+- Keep `.motoko/model-catalog.json` as picker/discovery configuration only;
+  runtime selection is resolved separately.
+- Add shared runtime model resolution for TUI and headless runs with precedence
+  `MODEL` environment variable, then profile `agent.model`, then the default
+  runtime model.
+- Publish the resolved runtime model back to `process.env.MODEL` before runtime
+  startup so env-server, scratchpad, subagents, and `RuntimeProcess` observe the
+  same model.
+- Update the configured direct Google/Vertex models to use bare `gemini-*` ids.
+- Add direct Gemini context-window entries for context accounting.
 - Kept the user-facing/profile model id intact for UI display, context
   accounting, and conversation model switching.
-- Added regression tests for OpenRouter, local OpenAI-compatible models with
-  and without slashful ids, Google, and Ollama.
+- Added regression tests for OpenRouter pinned models, `openrouter/auto`, local
+  OpenAI-compatible models with and without slashful ids, OpenRouter
+  vendor/model ids, Ollama, shared runtime model resolution, model catalog
+  loading, and direct Gemini picker entries.
 - Wrote PR notes to `.agent/prs/mot-21-fix-local-model-routing.md`.
 
 ## Verification
 
 - `ailang check src/core/agent_loop_v2.ail`
 - `ailang test src/core/agent_loop_v2.ail`
+- `ailang check src/core/context_usage.ail`
+- `bun test src/tui/src/models.test.ts`
+- `bun run --cwd src/tui build`
 - Headless local smoke:
 
 ```bash
@@ -43,6 +68,6 @@ The smoke completed and returned `ok` without the invalid model id error.
 
 ## Notes
 
-The AILANG MCP server is configured in `.mcp.json`, but no MCP resources were
-available in this Codex session. Local AILANG docs were consulted via the
-vendored `ailang/std` path instead.
+The AILANG MCP server in `.mcp.json` was consulted directly over HTTP. It
+served AILANG `0.25.0` docs, including `std/ai`, `guides/ai-routing.md`, and
+`guides/custom-ai-providers.md`.

--- a/.motoko/config/local/compaction_ai.json
+++ b/.motoko/config/local/compaction_ai.json
@@ -1,5 +1,5 @@
 {
-  "model": "openrouter/deepseek/deepseek-v4-flash",
+  "model": "openai/deepseek-v4-flash",
   "threshold_pct": 75,
   "keep_recent": 10
 }

--- a/.motoko/config/local/config.json
+++ b/.motoko/config/local/config.json
@@ -31,7 +31,7 @@
     "edit_mode": "hashline"
   },
   "extensions": {
-    "order": ["compaction_ai", "context_mode", "exa_search", "omnigraph"],
+    "order": ["compaction_ai", "context_mode", "exa_search", "scratchpad", "ailang_docs"],
     "strict": false
   },
   "verification": {}

--- a/.motoko/config/local/config.json
+++ b/.motoko/config/local/config.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "model": "openai/google/gemma-4-26B-A4B-it",
+    "model": "openai/deepseek-v4-flash",
     "workdir": ".",
     "max_steps": 50,
     "step_delay_ms": 0,

--- a/.motoko/model-catalog.json
+++ b/.motoko/model-catalog.json
@@ -1,0 +1,24 @@
+{
+  "known_models": [
+    "anthropic/claude-sonnet-4-6",
+    "anthropic/claude-opus-4-6",
+    "anthropic/claude-haiku-4-5",
+    "openai/gpt-4o",
+    "openai/gpt-4o-mini",
+    "gemini-2.5-flash",
+    "gemini-2.5-pro",
+    "ollama/llama3.2"
+  ],
+  "openrouter_fallback_models": [
+    "openrouter/anthropic/claude-sonnet-4-5",
+    "openrouter/anthropic/claude-opus-4-5",
+    "openrouter/openai/gpt-4o",
+    "openrouter/openai/gpt-4o-mini",
+    "openrouter/google/gemini-2.5-pro",
+    "openrouter/google/gemini-2.5-flash",
+    "openrouter/meta-llama/llama-3.3-70b-instruct",
+    "openrouter/mistralai/mixtral-8x7b-instruct",
+    "openrouter/deepseek/deepseek-r1",
+    "openrouter/qwen/qwen-2.5-72b-instruct"
+  ]
+}

--- a/.motoko/model-catalog.json
+++ b/.motoko/model-catalog.json
@@ -20,5 +20,26 @@
     "openrouter/mistralai/mixtral-8x7b-instruct",
     "openrouter/deepseek/deepseek-r1",
     "openrouter/qwen/qwen-2.5-72b-instruct"
-  ]
+  ],
+  "context_limits": {
+    "anthropic/claude-sonnet-4-6": 200000,
+    "anthropic/claude-sonnet-4-5": 200000,
+    "anthropic/claude-opus-4-6": 200000,
+    "anthropic/claude-opus-4-7": 1000000,
+    "anthropic/claude-haiku-4-5": 200000,
+    "openai/gpt-4o": 128000,
+    "openai/gpt-4o-mini": 128000,
+    "openai/gpt-5": 400000,
+    "gemini-2.5-flash": 1000000,
+    "gemini-2.5-pro": 2000000,
+    "google/gemini-2.5-flash": 1000000,
+    "google/gemini-2.5-pro": 2000000,
+    "z-ai/glm-5": 128000,
+    "minimax/minimax-m2.7": 256000,
+    "x-ai/grok-3": 131072,
+    "deepseek/deepseek-v4-pro": 1000000,
+    "deepseek/deepseek-v4-flash": 1000000,
+    "deepseek/deepseek-v4-flash:free": 1000000,
+    "test/tiny": 100
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 PROFILE ?= $(if $(MOTOKO_CONFIG),$(MOTOKO_CONFIG),default)
-AILANG_BIN ?= $(CURDIR)/ailang/bin/ailang
 
 codex:
 	clear
@@ -13,12 +12,9 @@ prune:
 	docker system prune -a
 
 # Mirror extension source packages into .packages/motoko_* for runtime extension loading.
-build_ailang:
-	cd ailang && make build
-
-sync_packages: build_ailang
-	AILANG_BIN=$(AILANG_BIN) ./scripts/sync-extension-packages.sh
-	$(AILANG_BIN) lock
+sync_packages:
+	./scripts/sync-extension-packages.sh
+	ailang lock
 
 # M-MOTOKO-OHMY-PI-DEFAULT-FLIP regression guard: assert every shipped config
 # profile has tools.ohmy_pi=false. Until M-MOTOKO-M6.5 (env-server inbox-based
@@ -52,12 +48,12 @@ smoke_no_delegated_storm:
 check_core: verify_extensions
 	@ok=0; fail=0; \
 	for f in src/core/*.ail; do \
-		if $(AILANG_BIN) check "$$f" >/dev/null 2>&1; then \
+		if ailang check "$$f" >/dev/null 2>&1; then \
 			echo "  ✓ $$f"; \
 			ok=$$((ok + 1)); \
 		else \
 			echo "  ✗ $$f"; \
-			$(AILANG_BIN) check "$$f" 2>&1 | tail -3; \
+			ailang check "$$f" 2>&1 | tail -3; \
 			fail=$$((fail + 1)); \
 		fi; \
 	done; \
@@ -89,7 +85,7 @@ verify_extensions:
 	for ext in $$exts; do \
 		out=$$(MOTOKO_PROFILE_DIR="$$PWD/.motoko/config/$$profile" \
 		      AILANG_RELAX_MODULES=1 \
-		      $(AILANG_BIN) run --caps Net,AI,SharedMem,IO,Env,Clock,FS,Process,Stream \
+		      ailang run --caps Net,AI,SharedMem,IO,Env,Clock,FS,Process,Stream \
 		        --ai-stub --entry main \
 		        scripts/verify_extension_boot.ail -- "$$ext" 2>&1); \
 		rc=$$?; \
@@ -115,7 +111,7 @@ init-config:
 	bun src/tui/src/init-config.ts --profile $(PROFILE) $(ARGS)
 
 # Build everything
-build: build_ailang sync_packages check_core build_tui
+build: sync_packages check_core build_tui
 
 # Run the agent
 run: build
@@ -129,14 +125,14 @@ install:
 # Run all core runtime module tests
 test_core:
 	@echo "Running src/core/agents_md.ail tests..."
-	@$(AILANG_BIN) test src/core/agents_md.ail || (echo "src/core/agents_md.ail tests failed" && exit 1)
+	@ailang test src/core/agents_md.ail || (echo "src/core/agents_md.ail tests failed" && exit 1)
 	@echo "Running src/core/parse_test.ail tests..."
-	@$(AILANG_BIN) test src/core/parse_test.ail || (echo "src/core/parse_test.ail tests failed" && exit 1)
+	@ailang test src/core/parse_test.ail || (echo "src/core/parse_test.ail tests failed" && exit 1)
 	@printf "\nAll core runtime module tests passed!\n"
 
 test_integration:
 	@echo "Running src/core/test/integration_tests.ail tests..."
-	@$(AILANG_BIN) test src/core/test/integration_tests.ail || (echo "src/core/test/integration_tests.ail tests failed" && exit 1)
+	@ailang test src/core/test/integration_tests.ail || (echo "src/core/test/integration_tests.ail tests failed" && exit 1)
 	@printf "\nAll integration tests passed!\n"
 
 test: test_core
@@ -149,7 +145,7 @@ verify_core:
 	@ok=0; fail=0; none=0; \
 	for f in src/core/*.ail; do \
 		case "$$f" in *_test.ail) continue ;; esac; \
-		out="$$($(AILANG_BIN) verify "$$f" 2>&1)"; \
+		out="$$(ailang verify "$$f" 2>&1)"; \
 		rc=$$?; \
 		if [ $$rc -ne 0 ]; then \
 			echo "  ✗ $$f"; \
@@ -170,7 +166,7 @@ verify_core:
 verify_ext:
 	@ok=0; fail=0; none=0; \
 	for f in $$(find src/core/ext -name "*.ail" ! -name "*_test.ail"); do \
-		out="$$($(AILANG_BIN) verify "$$f" 2>&1)"; \
+		out="$$(ailang verify "$$f" 2>&1)"; \
 		rc=$$?; \
 		if [ $$rc -ne 0 ]; then \
 			echo "  ✗ $$f"; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PROFILE ?= $(if $(MOTOKO_CONFIG),$(MOTOKO_CONFIG),default)
+AILANG_BIN ?= $(CURDIR)/ailang/bin/ailang
 
 codex:
 	clear
@@ -12,9 +13,12 @@ prune:
 	docker system prune -a
 
 # Mirror extension source packages into .packages/motoko_* for runtime extension loading.
-sync_packages:
-	./scripts/sync-extension-packages.sh
-	ailang lock
+build_ailang:
+	cd ailang && make build
+
+sync_packages: build_ailang
+	AILANG_BIN=$(AILANG_BIN) ./scripts/sync-extension-packages.sh
+	$(AILANG_BIN) lock
 
 # M-MOTOKO-OHMY-PI-DEFAULT-FLIP regression guard: assert every shipped config
 # profile has tools.ohmy_pi=false. Until M-MOTOKO-M6.5 (env-server inbox-based
@@ -48,12 +52,12 @@ smoke_no_delegated_storm:
 check_core: verify_extensions
 	@ok=0; fail=0; \
 	for f in src/core/*.ail; do \
-		if ailang check "$$f" >/dev/null 2>&1; then \
+		if $(AILANG_BIN) check "$$f" >/dev/null 2>&1; then \
 			echo "  ✓ $$f"; \
 			ok=$$((ok + 1)); \
 		else \
 			echo "  ✗ $$f"; \
-			ailang check "$$f" 2>&1 | tail -3; \
+			$(AILANG_BIN) check "$$f" 2>&1 | tail -3; \
 			fail=$$((fail + 1)); \
 		fi; \
 	done; \
@@ -70,7 +74,7 @@ check_core: verify_extensions
 # mask the status of the others. Set MOTOKO_CONFIG=<profile> to probe a
 # different profile (default: current MOTOKO_CONFIG or "default").
 verify_extensions:
-	@profile=$${MOTOKO_CONFIG:-default}; \
+	@profile=$${MOTOKO_CONFIG:-$(PROFILE)}; \
 	cfg=".motoko/config/$$profile/config.json"; \
 	if [ ! -f "$$cfg" ]; then \
 		echo "verify_extensions: no config at $$cfg — skipping"; \
@@ -85,7 +89,7 @@ verify_extensions:
 	for ext in $$exts; do \
 		out=$$(MOTOKO_PROFILE_DIR="$$PWD/.motoko/config/$$profile" \
 		      AILANG_RELAX_MODULES=1 \
-		      ailang run --caps Net,AI,SharedMem,IO,Env,Clock,FS,Process,Stream \
+		      $(AILANG_BIN) run --caps Net,AI,SharedMem,IO,Env,Clock,FS,Process,Stream \
 		        --ai-stub --entry main \
 		        scripts/verify_extension_boot.ail -- "$$ext" 2>&1); \
 		rc=$$?; \
@@ -111,7 +115,7 @@ init-config:
 	bun src/tui/src/init-config.ts --profile $(PROFILE) $(ARGS)
 
 # Build everything
-build: sync_packages check_core build_tui
+build: build_ailang sync_packages check_core build_tui
 
 # Run the agent
 run: build
@@ -125,14 +129,14 @@ install:
 # Run all core runtime module tests
 test_core:
 	@echo "Running src/core/agents_md.ail tests..."
-	@ailang test src/core/agents_md.ail || (echo "src/core/agents_md.ail tests failed" && exit 1)
+	@$(AILANG_BIN) test src/core/agents_md.ail || (echo "src/core/agents_md.ail tests failed" && exit 1)
 	@echo "Running src/core/parse_test.ail tests..."
-	@ailang test src/core/parse_test.ail || (echo "src/core/parse_test.ail tests failed" && exit 1)
+	@$(AILANG_BIN) test src/core/parse_test.ail || (echo "src/core/parse_test.ail tests failed" && exit 1)
 	@printf "\nAll core runtime module tests passed!\n"
 
 test_integration:
 	@echo "Running src/core/test/integration_tests.ail tests..."
-	@ailang test src/core/test/integration_tests.ail || (echo "src/core/test/integration_tests.ail tests failed" && exit 1)
+	@$(AILANG_BIN) test src/core/test/integration_tests.ail || (echo "src/core/test/integration_tests.ail tests failed" && exit 1)
 	@printf "\nAll integration tests passed!\n"
 
 test: test_core
@@ -145,7 +149,7 @@ verify_core:
 	@ok=0; fail=0; none=0; \
 	for f in src/core/*.ail; do \
 		case "$$f" in *_test.ail) continue ;; esac; \
-		out="$$(ailang verify "$$f" 2>&1)"; \
+		out="$$($(AILANG_BIN) verify "$$f" 2>&1)"; \
 		rc=$$?; \
 		if [ $$rc -ne 0 ]; then \
 			echo "  ✗ $$f"; \
@@ -166,7 +170,7 @@ verify_core:
 verify_ext:
 	@ok=0; fail=0; none=0; \
 	for f in $$(find src/core/ext -name "*.ail" ! -name "*_test.ail"); do \
-		out="$$(ailang verify "$$f" 2>&1)"; \
+		out="$$($(AILANG_BIN) verify "$$f" 2>&1)"; \
 		rc=$$?; \
 		if [ $$rc -ne 0 ]; then \
 			echo "  ✗ $$f"; \

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Model selection and model discovery are separate:
   `.motoko/model-catalog.json`. Set
   `MOTOKO_MODELS_FILE=/path/to/model-catalog.json` to use
   a different catalog.
+- Known per-model context windows also live in `.motoko/model-catalog.json`
+  under `context_limits`. Motoko uses them for context telemetry and
+  compaction; unknown models fall back to broad provider-family defaults or no
+  compaction when the limit is unknown.
 - Dynamic suggestions from `OPENAI_BASE_URL` and OpenRouter are merged into the
   picker catalog at runtime. They do not override the selected runtime model.
 - Ollama models are selected explicitly with `ollama/<model>`, either in

--- a/README.md
+++ b/README.md
@@ -101,6 +101,39 @@ Per-extension JSON files are optional; if missing, hardcoded defaults apply.
 
 Precedence: hardcoded defaults < profile JSON < CLI args. API keys are always env vars.
 
+### Model identifiers
+
+Model selection and model discovery are separate:
+
+- Runtime model resolution is shared by TUI and headless runs:
+  `MODEL` env var > profile `agent.model` > `anthropic/claude-sonnet-4-6`.
+- The TUI `/model` picker loads its baseline suggestion catalog from
+  `.motoko/model-catalog.json`. Set
+  `MOTOKO_MODELS_FILE=/path/to/model-catalog.json` to use
+  a different catalog.
+- Dynamic suggestions from `OPENAI_BASE_URL` and OpenRouter are merged into the
+  picker catalog at runtime. They do not override the selected runtime model.
+- Ollama models are selected explicitly with `ollama/<model>`, either in
+  `MODEL`, profile `agent.model`, or `.motoko/model-catalog.json`. They are not
+  auto-discovered by the picker.
+
+Motoko model strings are intentionally close to AILANG's provider routing
+syntax, but a few prefixes have provider-specific meanings:
+
+| Goal | Model string | Notes |
+|---|---|---|
+| Direct Anthropic | `anthropic/claude-sonnet-4-6` | Requires `ANTHROPIC_API_KEY`. |
+| Direct OpenAI | `openai/gpt-4o` | Requires `OPENAI_API_KEY`, unless `OPENAI_BASE_URL` points at a local OpenAI-compatible endpoint. |
+| Local OpenAI-compatible | `openai/deepseek-v4-flash` | Motoko strips the leading `openai/` before sending the model id to `OPENAI_BASE_URL`. Slashful local ids also work, e.g. `openai/google/gemma-4-26B-A4B-it` becomes `google/gemma-4-26B-A4B-it`. |
+| Direct Google Gemini / Vertex | `gemini-2.5-flash` | AILANG selects the Google provider from the bare `gemini-*` prefix. It tries Vertex ADC first, then falls back to `GOOGLE_API_KEY` for AI Studio. |
+| OpenRouter pinned model | `openrouter/google/gemini-2.5-flash` | Motoko strips only the outer `openrouter/`; OpenRouter receives `google/gemini-2.5-flash`. |
+| OpenRouter routing policy | `openrouter/auto` | Preserved as-is for AILANG/OpenRouter routing. |
+| Ollama | `ollama/llama3.2` | Preserved for AILANG to route to the native Ollama provider. Use any model name installed in your local Ollama server after the `ollama/` prefix. |
+
+Important distinction: `google/gemini-2.5-flash` is an OpenRouter vendor/model
+id in AILANG's routing rules, not the direct Vertex form. Use bare
+`gemini-2.5-flash` for direct Google Gemini / Vertex.
+
 ## Usage
 
 ### How it works

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Model selection and model discovery are separate:
   a different catalog.
 - Known per-model context windows also live in `.motoko/model-catalog.json`
   under `context_limits`. Motoko uses them for context telemetry and
-  compaction; unknown models fall back to broad provider-family defaults or no
-  compaction when the limit is unknown.
+  compaction. Unknown or uncatalogued models have no known limit, so
+  compaction is skipped rather than guessed from provider-family prefixes.
 - Dynamic suggestions from `OPENAI_BASE_URL` and OpenRouter are merged into the
   picker catalog at runtime. They do not override the selected runtime model.
 - Ollama models are selected explicitly with `ollama/<model>`, either in

--- a/ailang.lock
+++ b/ailang.lock
@@ -1,7 +1,7 @@
 {
-  "ailang_version": "v0.24.2",
-  "generated_at": "2026-06-22T19:42:19.241334871Z",
-  "generator": "ailang lock v0.24.2",
+  "ailang_version": "v0.25.0-165-gfbe4576fa-dirty",
+  "generated_at": "2026-06-23T10:40:49.319368382Z",
+  "generator": "ailang lock v0.25.0-165-gfbe4576fa-dirty",
   "packages": [
     {
       "ailang": ">=0.9.2",

--- a/ailang.lock
+++ b/ailang.lock
@@ -1,7 +1,7 @@
 {
-  "ailang_version": "v0.25.0-328-g1a56ed218",
-  "generated_at": "2026-06-23T19:16:00.889226329Z",
-  "generator": "ailang lock v0.25.0-328-g1a56ed218",
+  "ailang_version": "v0.24.2",
+  "generated_at": "2026-06-23T19:59:16.880404749Z",
+  "generator": "ailang lock v0.24.2",
   "packages": [
     {
       "ailang": ">=0.9.2",

--- a/ailang.lock
+++ b/ailang.lock
@@ -1,7 +1,7 @@
 {
-  "ailang_version": "v0.25.0-165-gfbe4576fa-dirty",
-  "generated_at": "2026-06-23T10:40:49.319368382Z",
-  "generator": "ailang lock v0.25.0-165-gfbe4576fa-dirty",
+  "ailang_version": "v0.25.0-328-g1a56ed218",
+  "generated_at": "2026-06-23T19:16:00.889226329Z",
+  "generator": "ailang lock v0.25.0-328-g1a56ed218",
   "packages": [
     {
       "ailang": ">=0.9.2",

--- a/ailang.lock
+++ b/ailang.lock
@@ -1,6 +1,6 @@
 {
   "ailang_version": "v0.24.2",
-  "generated_at": "2026-06-21T12:00:58.941848763Z",
+  "generated_at": "2026-06-22T19:42:19.241334871Z",
   "generator": "ailang lock v0.24.2",
   "packages": [
     {

--- a/scripts/smoke_catalog_compaction.ail
+++ b/scripts/smoke_catalog_compaction.ail
@@ -1,0 +1,60 @@
+-- scripts/smoke_catalog_compaction.ail
+--
+-- Runtime smoke for catalog-backed context limits and structural compaction.
+--
+-- This deliberately exercises the effectful path:
+--   .motoko/model-catalog.json -> catalog_context_limit_for -> compact_step_with_limit
+--
+-- Setup:
+--   ailang run --caps IO,FS,Env --entry main scripts/smoke_catalog_compaction.ail
+
+module scripts/smoke_catalog_compaction
+
+import std/ai (Message)
+import std/io (println, exit)
+import std/result (Ok, Err)
+import std/string (repeat)
+import src/core/context_usage (catalog_context_limit_for)
+import src/core/compaction (compact_step_with_limit)
+
+func msg(role: string, content: string, tool_call_id: string) -> Message {
+  {
+    role: role,
+    content: content,
+    tool_calls: [],
+    tool_call_id: tool_call_id
+  }
+}
+
+func fail(message: string) -> () ! {IO} {
+  let _ = println("FAIL: ${message}");
+  exit(1)
+}
+
+export func main() -> () ! {IO, FS, Env} {
+  let model = "test/tiny";
+  let limit = catalog_context_limit_for(model);
+  let _ =
+    if limit == 100 then println("PASS: catalog_context_limit_for(test/tiny)=100")
+    else fail("expected catalog limit 100 for test/tiny, got ${show(limit)}");
+
+  -- A large user message cannot be structurally elided. With the catalog's
+  -- 100-token test limit, compact_step_with_limit must report exhaustion.
+  let oversized_history: [Message] = [
+    msg("user", repeat("x", 390), ""),
+    msg("tool", "short tool result", "call-smoke")
+  ];
+  let _ = match compact_step_with_limit(oversized_history, model, limit) {
+    Err(reason) => println("PASS: compaction exhausted with catalog limit: ${reason}"),
+    Ok(_) => fail("expected compaction_exhausted for oversized history")
+  };
+
+  -- Unknown models have no hardcoded provider-family fallback. They should
+  -- resolve to 0 and therefore skip compaction rather than guessing.
+  let unknown = catalog_context_limit_for("anthropic/unlisted-future-model");
+  let _ =
+    if unknown == 0 then println("PASS: uncatalogued model has no guessed limit")
+    else fail("uncatalogued model unexpectedly got limit ${show(unknown)}");
+
+  println("--- catalog compaction smoke complete ---")
+}

--- a/scripts/sync-extension-packages.sh
+++ b/scripts/sync-extension-packages.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AILANG_BIN="${AILANG_BIN:-ailang}"
 
 sync_extension() {
   local ext_name="$1"
@@ -58,7 +59,7 @@ sync_extension() {
   # Pre-fix this hard-failed CI on PR #22 because src/core/ext/context_mode/
   # only shipped register.ail with no manifest.
   if [[ -f "$pkg_dir/ailang.toml" ]]; then
-    (cd "$pkg_dir" && ailang lock)
+    (cd "$pkg_dir" && "$AILANG_BIN" lock)
   else
     echo "  (no ailang.toml in $pkg_dir — local-only override, skipping lock)" >&2
   fi

--- a/scripts/sync-extension-packages.sh
+++ b/scripts/sync-extension-packages.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-AILANG_BIN="${AILANG_BIN:-ailang}"
 
 sync_extension() {
   local ext_name="$1"
@@ -59,7 +58,7 @@ sync_extension() {
   # Pre-fix this hard-failed CI on PR #22 because src/core/ext/context_mode/
   # only shipped register.ail with no manifest.
   if [[ -f "$pkg_dir/ailang.toml" ]]; then
-    (cd "$pkg_dir" && "$AILANG_BIN" lock)
+    (cd "$pkg_dir" && ailang lock)
   else
     echo "  (no ailang.toml in $pkg_dir — local-only override, skipping lock)" >&2
   fi

--- a/src/core/agent_loop_v2.ail
+++ b/src/core/agent_loop_v2.ail
@@ -65,23 +65,24 @@ import pkg/sunholo/motoko_ext_scratchpad/ws_loopback (exec_scratchpad_cell_ws)
 -- Convert Motoko's UI/profile model identifier to the provider API model id
 -- expected by upstream stepWithStream(). The --ai flag already selected the
 -- handler/provider; the model argument passed to step is forwarded to the
--- upstream API body. Keep OpenRouter's vendor/model id intact after stripping
--- only the Motoko routing prefix.
-pure func provider_api_model(model: string) -> string {
-  if startsWith(model, "openrouter/") then
+-- upstream API body.
+--
+-- Important: OpenRouter's API model ids are themselves vendor/model strings
+-- such as "anthropic/claude-sonnet-4-6" and "openai/gpt-4o". Strip the
+-- explicit Motoko/OpenRouter routing prefix only for pinned vendor/model ids;
+-- keep "openrouter/auto" intact because AILANG/OpenRouter use it as the
+-- routing-policy model. Strip "openai/" only when a custom OpenAI-compatible
+-- base URL is configured, where "openai/<local-id>" is Motoko UI routing
+-- syntax rather than an OpenRouter vendor/model id.
+pure func provider_api_model(model: string, openai_base_url: string) -> string {
+  if model == "openrouter/auto" then
+    model
+  else if startsWith(model, "openrouter/") then
     let prefix_len = Str.length("openrouter/") in
     let total = Str.length(model) in
     substring(model, prefix_len, total)
-  else if startsWith(model, "openai/") then
+  else if openai_base_url != "" && startsWith(model, "openai/") then
     let prefix_len = Str.length("openai/") in
-    let total = Str.length(model) in
-    substring(model, prefix_len, total)
-  else if startsWith(model, "google/") then
-    let prefix_len = Str.length("google/") in
-    let total = Str.length(model) in
-    substring(model, prefix_len, total)
-  else if startsWith(model, "anthropic/") then
-    let prefix_len = Str.length("anthropic/") in
     let total = Str.length(model) in
     substring(model, prefix_len, total)
   else
@@ -413,31 +414,49 @@ pure func test_cap_tool_message_content_truncates_oversized_content() -> bool
 pure func test_provider_api_model_openrouter_keeps_vendor_model() -> bool
   tests [((), true)]
   {
-    provider_api_model("openrouter/deepseek/deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
+    provider_api_model("openrouter/deepseek/deepseek-v4-flash", "") == "deepseek/deepseek-v4-flash"
+  }
+
+pure func test_provider_api_model_openrouter_auto_stays_intact() -> bool
+  tests [((), true)]
+  {
+    provider_api_model("openrouter/auto", "") == "openrouter/auto"
   }
 
 pure func test_provider_api_model_local_openai_strips_routing_prefix() -> bool
   tests [((), true)]
   {
-    provider_api_model("openai/deepseek-v4-flash") == "deepseek-v4-flash"
+    provider_api_model("openai/deepseek-v4-flash", "http://127.0.0.1:8000/v1") == "deepseek-v4-flash"
   }
 
 pure func test_provider_api_model_local_openai_preserves_slashful_id() -> bool
   tests [((), true)]
   {
-    provider_api_model("openai/google/gemma-4-26B-A4B-it") == "google/gemma-4-26B-A4B-it"
+    provider_api_model("openai/google/gemma-4-26B-A4B-it", "http://127.0.0.1:8000/v1") == "google/gemma-4-26B-A4B-it"
   }
 
-pure func test_provider_api_model_direct_google_strips_routing_prefix() -> bool
+pure func test_provider_api_model_openrouter_openai_vendor_model_stays_intact() -> bool
   tests [((), true)]
   {
-    provider_api_model("google/gemini-2.5-flash") == "gemini-2.5-flash"
+    provider_api_model("openai/gpt-4o", "") == "openai/gpt-4o"
+  }
+
+pure func test_provider_api_model_openrouter_anthropic_vendor_model_stays_intact() -> bool
+  tests [((), true)]
+  {
+    provider_api_model("anthropic/claude-sonnet-4-6", "") == "anthropic/claude-sonnet-4-6"
+  }
+
+pure func test_provider_api_model_openrouter_google_vendor_model_stays_intact() -> bool
+  tests [((), true)]
+  {
+    provider_api_model("google/gemini-2.5-flash", "") == "google/gemini-2.5-flash"
   }
 
 pure func test_provider_api_model_ollama_keeps_routing_prefix_for_provider() -> bool
   tests [((), true)]
   {
-    provider_api_model("ollama/qwen3.5:35b-a3b-mxfp8") == "ollama/qwen3.5:35b-a3b-mxfp8"
+    provider_api_model("ollama/qwen3.5:35b-a3b-mxfp8", "") == "ollama/qwen3.5:35b-a3b-mxfp8"
   }
 
 func result_env_model_content(result: ToolResultEnvelope) -> string {
@@ -1167,7 +1186,7 @@ func loop_v2(
     -- Match-in-lambda is a known AILANG parser bug, so the match lives in
     -- the top-level emit_stream_chunk helper.
     let on_chunk: (StreamChunk) -> () ! {IO} = \chunk. emit_stream_chunk(session_id, step_idx, stream_id, chunk);
-    let dispatched = dispatch_step(provider, provider_api_model(model), compacted_msgs, rt, on_chunk);
+    let dispatched = dispatch_step(provider, provider_api_model(model, getEnvOr("OPENAI_BASE_URL", "")), compacted_msgs, rt, on_chunk);
     let next_provider = dispatched.next_provider;
     match dispatched.result {
       Err(e) => {

--- a/src/core/agent_loop_v2.ail
+++ b/src/core/agent_loop_v2.ail
@@ -55,8 +55,8 @@ import src/core/types (Msg, ToolBackend)
 import src/core/config (CostRates)
 import std/option (Option, Some, None)
 import pkg/sunholo/motoko_ext_abi/types (BudgetPlan, ExtCtx, ExtRuntime, PolicyDefault, ResponseInterceptDecision, FinalizeDecision, ToolPolicyDecision, ToolHandleDecision, ExtensionHooks)
-import src/core/compaction (compact_step)
-import src/core/context_usage (context_limit_for)
+import src/core/compaction (compact_step_with_limit)
+import src/core/context_usage (catalog_context_limit_for)
 import src/core/ext/runtime (dispatch_response_intercept, dispatch_solver_candidate, dispatch_tool_policy, dispatch_tool_handle, dispatch_pre_step)
 import pkg/sunholo/motoko_ext_abi/types (PreStepDecision, PassThrough, Compacted)
 import src/core/test/stub_step (StepProvider, dispatch_step, LiveAI, Scripted, ScriptedStep)
@@ -71,9 +71,12 @@ import pkg/sunholo/motoko_ext_scratchpad/ws_loopback (exec_scratchpad_cell_ws)
 -- such as "anthropic/claude-sonnet-4-6" and "openai/gpt-4o". Strip the
 -- explicit Motoko/OpenRouter routing prefix only for pinned vendor/model ids;
 -- keep "openrouter/auto" intact because AILANG/OpenRouter use it as the
--- routing-policy model. Strip "openai/" only when a custom OpenAI-compatible
--- base URL is configured, where "openai/<local-id>" is Motoko UI routing
--- syntax rather than an OpenRouter vendor/model id.
+-- routing-policy model.
+--
+-- Direct provider prefixes are Motoko routing syntax and are stripped before
+-- the provider request. AILANG itself treats vendor/model strings such as
+-- "openai/..." and "anthropic/..." as OpenRouter, so the TS launcher also
+-- strips those prefixes for --ai provider selection.
 pure func provider_api_model(model: string, openai_base_url: string) -> string {
   if model == "openrouter/auto" then
     model
@@ -81,8 +84,16 @@ pure func provider_api_model(model: string, openai_base_url: string) -> string {
     let prefix_len = Str.length("openrouter/") in
     let total = Str.length(model) in
     substring(model, prefix_len, total)
-  else if openai_base_url != "" && startsWith(model, "openai/") then
+  else if startsWith(model, "openai/") then
     let prefix_len = Str.length("openai/") in
+    let total = Str.length(model) in
+    substring(model, prefix_len, total)
+  else if startsWith(model, "anthropic/") then
+    let prefix_len = Str.length("anthropic/") in
+    let total = Str.length(model) in
+    substring(model, prefix_len, total)
+  else if startsWith(model, "google/") then
+    let prefix_len = Str.length("google/") in
     let total = Str.length(model) in
     substring(model, prefix_len, total)
   else
@@ -435,22 +446,22 @@ pure func test_provider_api_model_local_openai_preserves_slashful_id() -> bool
     provider_api_model("openai/google/gemma-4-26B-A4B-it", "http://127.0.0.1:8000/v1") == "google/gemma-4-26B-A4B-it"
   }
 
-pure func test_provider_api_model_openrouter_openai_vendor_model_stays_intact() -> bool
+pure func test_provider_api_model_direct_openai_strips_routing_prefix() -> bool
   tests [((), true)]
   {
-    provider_api_model("openai/gpt-4o", "") == "openai/gpt-4o"
+    provider_api_model("openai/gpt-4o", "") == "gpt-4o"
   }
 
-pure func test_provider_api_model_openrouter_anthropic_vendor_model_stays_intact() -> bool
+pure func test_provider_api_model_direct_anthropic_strips_routing_prefix() -> bool
   tests [((), true)]
   {
-    provider_api_model("anthropic/claude-sonnet-4-6", "") == "anthropic/claude-sonnet-4-6"
+    provider_api_model("anthropic/claude-sonnet-4-6", "") == "claude-sonnet-4-6"
   }
 
-pure func test_provider_api_model_openrouter_google_vendor_model_stays_intact() -> bool
+pure func test_provider_api_model_direct_google_strips_routing_prefix() -> bool
   tests [((), true)]
   {
-    provider_api_model("google/gemini-2.5-flash", "") == "google/gemini-2.5-flash"
+    provider_api_model("google/gemini-2.5-flash", "") == "gemini-2.5-flash"
   }
 
 pure func test_provider_api_model_ollama_keeps_routing_prefix_for_provider() -> bool
@@ -501,7 +512,8 @@ func mk_v2_ext_ctx(
   env_url: string,
   hybrid_tools: bool,
   budget: BudgetPlan,
-  history: [Message]
+  history: [Message],
+  context_limit: int
 ) -> ExtCtx {
   let remaining = if budget.total - step_idx < 0 then 0 else budget.total - step_idx;
   {
@@ -517,7 +529,7 @@ func mk_v2_ext_ctx(
     budget_remaining: remaining,
     history_slice: messages_to_msgs(history),
     state_key: "core:ext:v2",
-    context_limit: context_limit_for(model)
+    context_limit: context_limit
   }
 }
 
@@ -1134,8 +1146,9 @@ func loop_v2(
     })
   }
   else {
+  let context_limit = catalog_context_limit_for(model);
   -- Build extension context for this step (needed for dispatch_pre_step)
-  let ctx = mk_v2_ext_ctx(task, step_idx, model, workdir, env_url, hybrid_tools, budget, msgs);
+  let ctx = mk_v2_ext_ctx(task, step_idx, model, workdir, env_url, hybrid_tools, budget, msgs, context_limit);
   
   -- DP0a: let extensions compact first (e.g., AI summarization)
   let after_ext = match dispatch_pre_step(rt, ctx, messages_to_msgs(msgs)) {
@@ -1155,7 +1168,7 @@ func loop_v2(
   -- DP0b: structural compaction as fallback
   -- compact_step is a no-op below 70% usage; elides old tool_result content
   -- at 70-85% and 85-95%; at ≥95% tries emergency compaction.
-  match compact_step(msgs_after_ext, model) {
+  match compact_step_with_limit(msgs_after_ext, model, context_limit) {
     Err(compaction_reason) => {
       let _ = emit_event(session_id, "compaction_exhausted", [
         kv("step", jnum(_int_to_float(step_idx))),
@@ -1221,7 +1234,7 @@ func loop_v2(
 
         let assistant_msg = step_result_to_message(result);
         let msgs_with_assistant = msgs ++ [assistant_msg];
-        let ctx = mk_v2_ext_ctx(task, step_idx, model, workdir, env_url, hybrid_tools, budget, msgs_with_assistant);
+        let ctx = mk_v2_ext_ctx(task, step_idx, model, workdir, env_url, hybrid_tools, budget, msgs_with_assistant, context_limit);
 
         let new_total_cost = totals.cost_millicents + step_cost;
         let new_input  = totals.input_tokens  + result.input_tokens;

--- a/src/core/agent_loop_v2.ail
+++ b/src/core/agent_loop_v2.ail
@@ -62,14 +62,26 @@ import pkg/sunholo/motoko_ext_abi/types (PreStepDecision, PassThrough, Compacted
 import src/core/test/stub_step (StepProvider, dispatch_step, LiveAI, Scripted, ScriptedStep)
 import pkg/sunholo/motoko_ext_scratchpad/ws_loopback (exec_scratchpad_cell_ws)
 
--- Strip the "openrouter/" model prefix before forwarding to upstream step().
--- OpenRouter's API rejects the prefixed name. The fork's old code stored the
--- prefix as part of the model identifier for routing-style dispatch; with
--- upstream step() the AI handler is configured at --ai time, so the prefix
--- is redundant noise that breaks the upstream API call.
-func strip_provider_prefix(model: string) -> string {
+-- Convert Motoko's UI/profile model identifier to the provider API model id
+-- expected by upstream stepWithStream(). The --ai flag already selected the
+-- handler/provider; the model argument passed to step is forwarded to the
+-- upstream API body. Keep OpenRouter's vendor/model id intact after stripping
+-- only the Motoko routing prefix.
+pure func provider_api_model(model: string) -> string {
   if startsWith(model, "openrouter/") then
     let prefix_len = Str.length("openrouter/") in
+    let total = Str.length(model) in
+    substring(model, prefix_len, total)
+  else if startsWith(model, "openai/") then
+    let prefix_len = Str.length("openai/") in
+    let total = Str.length(model) in
+    substring(model, prefix_len, total)
+  else if startsWith(model, "google/") then
+    let prefix_len = Str.length("google/") in
+    let total = Str.length(model) in
+    substring(model, prefix_len, total)
+  else if startsWith(model, "anthropic/") then
+    let prefix_len = Str.length("anthropic/") in
     let total = Str.length(model) in
     substring(model, prefix_len, total)
   else
@@ -396,6 +408,36 @@ pure func test_cap_tool_message_content_truncates_oversized_content() -> bool
     let x1024 = "${x512}${x512}";
     let capped = cap_tool_message_content(x1024);
     Str.length(capped) == 65536 && contains(capped, "...[truncated; original ")
+  }
+
+pure func test_provider_api_model_openrouter_keeps_vendor_model() -> bool
+  tests [((), true)]
+  {
+    provider_api_model("openrouter/deepseek/deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
+  }
+
+pure func test_provider_api_model_local_openai_strips_routing_prefix() -> bool
+  tests [((), true)]
+  {
+    provider_api_model("openai/deepseek-v4-flash") == "deepseek-v4-flash"
+  }
+
+pure func test_provider_api_model_local_openai_preserves_slashful_id() -> bool
+  tests [((), true)]
+  {
+    provider_api_model("openai/google/gemma-4-26B-A4B-it") == "google/gemma-4-26B-A4B-it"
+  }
+
+pure func test_provider_api_model_direct_google_strips_routing_prefix() -> bool
+  tests [((), true)]
+  {
+    provider_api_model("google/gemini-2.5-flash") == "gemini-2.5-flash"
+  }
+
+pure func test_provider_api_model_ollama_keeps_routing_prefix_for_provider() -> bool
+  tests [((), true)]
+  {
+    provider_api_model("ollama/qwen3.5:35b-a3b-mxfp8") == "ollama/qwen3.5:35b-a3b-mxfp8"
   }
 
 func result_env_model_content(result: ToolResultEnvelope) -> string {
@@ -1125,7 +1167,7 @@ func loop_v2(
     -- Match-in-lambda is a known AILANG parser bug, so the match lives in
     -- the top-level emit_stream_chunk helper.
     let on_chunk: (StreamChunk) -> () ! {IO} = \chunk. emit_stream_chunk(session_id, step_idx, stream_id, chunk);
-    let dispatched = dispatch_step(provider, model, compacted_msgs, rt, on_chunk);
+    let dispatched = dispatch_step(provider, provider_api_model(model), compacted_msgs, rt, on_chunk);
     let next_provider = dispatched.next_provider;
     match dispatched.result {
       Err(e) => {
@@ -1420,12 +1462,11 @@ export func run_v2(
 ) -> Result[[Message], AIError] ! {AI, FS, Process, IO, Env, Net, SharedMem, Clock, Stream, Trace} {
   let budget_steps = if step_budget <= 0 then 8 else step_budget;
 	  let messages = msgs_to_messages(initial_msgs);
-	  let resolved_model = strip_provider_prefix(model);
 	  let session_id = derive_session_id();
 	  let started_at_ms = now();
 	  let session_span = "motoko.session.${session_id}";
 	  Trace.spanStart(session_span);
-	  let result = loop_v2(rt, task, env_url, hybrid_tools, budget, resolved_model, messages, workdir, 0, budget_steps, ohmy_pi, max_cost_millicents, cost_rates, zero_totals(), provider, session_id, started_at_ms);
+	  let result = loop_v2(rt, task, env_url, hybrid_tools, budget, model, messages, workdir, 0, budget_steps, ohmy_pi, max_cost_millicents, cost_rates, zero_totals(), provider, session_id, started_at_ms);
 	  Trace.spanEnd(session_span);
 	  result
 	}
@@ -1450,12 +1491,11 @@ export func run_v2_from_messages(
   provider: StepProvider
 ) -> Result[[Message], AIError] ! {AI, FS, Process, IO, Env, Net, SharedMem, Clock, Stream, Trace} {
   let budget_steps = if step_budget <= 0 then 8 else step_budget;
-	  let resolved_model = strip_provider_prefix(model);
 	  let session_id = derive_session_id();
 	  let started_at_ms = now();
 	  let session_span = "motoko.session.${session_id}";
 	  Trace.spanStart(session_span);
-	  let result = loop_v2(rt, task, env_url, hybrid_tools, budget, resolved_model, history, workdir, 0, budget_steps, ohmy_pi, max_cost_millicents, cost_rates, zero_totals(), provider, session_id, started_at_ms);
+	  let result = loop_v2(rt, task, env_url, hybrid_tools, budget, model, history, workdir, 0, budget_steps, ohmy_pi, max_cost_millicents, cost_rates, zero_totals(), provider, session_id, started_at_ms);
 	  Trace.spanEnd(session_span);
 	  result
 	}
@@ -1523,8 +1563,7 @@ export func conversation_loop_v2(
       if cmd_type == "abort" || cmd_type == "exit" then ()
       else if cmd_type == "model_change" then {
         let new_model = msg_get_str(obj, "model");
-        let resolved_new = strip_provider_prefix(new_model);
-        conversation_loop_v2(rt, env_url, hybrid_tools, budget, resolved_new, history, workdir, step_budget, ohmy_pi, max_cost_millicents, cost_rates, provider, session_id)
+        conversation_loop_v2(rt, env_url, hybrid_tools, budget, new_model, history, workdir, step_budget, ohmy_pi, max_cost_millicents, cost_rates, provider, session_id)
       }
       else if cmd_type == "restart" then {
         -- Emit session_suspend event and exit cleanly; TUI will respawn

--- a/src/core/compaction.ail
+++ b/src/core/compaction.ail
@@ -6,7 +6,7 @@
 -- Works on [Message] (upstream typed shape) so tool_call_id correlation
 -- is preserved — the provider needs those IDs for conversation continuation.
 --
--- Thresholds (usage = estimated_tokens / context_limit_for(model)):
+-- Thresholds (usage = estimated_tokens / loaded context limit):
 --   < 70%  → PassThrough (no compaction needed)
 --   70-85% → Elide tool_result content older than last 10 turns
 --   85-95% → Elide tool_result content older than last 5 turns
@@ -17,7 +17,7 @@
 -- loop iteration) always retains the original unelided messages. The
 -- compacted view is a transient input to step() for this step only.
 --
--- For unknown models (context_limit_for returns 0), compaction is skipped
+-- For unknown models (context limit is 0), compaction is skipped
 -- entirely — fail open rather than incorrectly refusing a valid step.
 
 module src/core/compaction
@@ -39,10 +39,13 @@ export pure func estimate_tokens_messages(msgs: [Message]) -> int {
 -- Context usage as integer percent (0-100). Returns 0 for unknown models.
 -- Uses integer arithmetic throughout to avoid float precision issues.
 -- contracts: SKIPPED — depends on foldl-based estimate_tokens_messages
-export pure func usage_percent(msgs: [Message], model: string) -> int {
-  let limit = context_limit_for(model);
+export pure func usage_percent_with_limit(msgs: [Message], limit: int) -> int {
   if limit == 0 then 0
   else (estimate_tokens_messages(msgs) * 100) / limit
+}
+
+export pure func usage_percent(msgs: [Message], model: string) -> int {
+  usage_percent_with_limit(msgs, context_limit_for(model))
 }
 
 -- Count tool-role messages in the list.
@@ -103,15 +106,15 @@ export pure func elide_old_tool_results(msgs: [Message], keep_last: int) -> [Mes
 
 -- Apply emergency compaction for ≥95% usage.
 -- Returns Ok(compacted) if we can get below 95%, otherwise Err.
-pure func try_emergency_compaction(msgs: [Message], model: string) -> Result[[Message], string] {
+pure func try_emergency_compaction_with_limit(msgs: [Message], model: string, limit: int) -> Result[[Message], string] {
   -- Try keeping only last 3 tool results
   let emergency1 = elide_old_tool_results(msgs, 3);
-  let pct1 = usage_percent(emergency1, model);
+  let pct1 = usage_percent_with_limit(emergency1, limit);
   if pct1 < 95 then Ok(emergency1)
   else {
     -- Try keeping only last 1 tool result
     let emergency2 = elide_old_tool_results(msgs, 1);
-    let pct2 = usage_percent(emergency2, model);
+    let pct2 = usage_percent_with_limit(emergency2, limit);
     if pct2 < 95 then Ok(emergency2)
     else {
       -- Even extreme compaction failed
@@ -120,16 +123,24 @@ pure func try_emergency_compaction(msgs: [Message], model: string) -> Result[[Me
   }
 }
 
+pure func try_emergency_compaction(msgs: [Message], model: string) -> Result[[Message], string] {
+  try_emergency_compaction_with_limit(msgs, model, context_limit_for(model))
+}
+
 -- Apply the default structural compaction policy for one step.
 -- Returns Ok(msgs) — possibly with elided tool content — or
 -- Err("compaction_exhausted") when the window is critically full.
 -- At ≥95%, attempts emergency compaction before failing.
-export pure func compact_step(msgs: [Message], model: string) -> Result[[Message], string] {
-  let pct = usage_percent(msgs, model);
-  if pct >= 95 then try_emergency_compaction(msgs, model)
+export pure func compact_step_with_limit(msgs: [Message], model: string, limit: int) -> Result[[Message], string] {
+  let pct = usage_percent_with_limit(msgs, limit);
+  if pct >= 95 then try_emergency_compaction_with_limit(msgs, model, limit)
   else if pct >= 85 then Ok(elide_old_tool_results(msgs, 5))
   else if pct >= 70 then Ok(elide_old_tool_results(msgs, 10))
   else Ok(msgs)
+}
+
+export pure func compact_step(msgs: [Message], model: string) -> Result[[Message], string] {
+  compact_step_with_limit(msgs, model, context_limit_for(model))
 }
 
 -- Unknown model → usage 0% → no compaction.
@@ -221,4 +232,3 @@ func emergency_compaction_tries_elision() -> bool
       Err(_) => false
     }
   }
-

--- a/src/core/context_usage.ail
+++ b/src/core/context_usage.ail
@@ -2,6 +2,11 @@ module src/core/context_usage
 
 import std/string (length, startsWith, substring)
 import std/list (foldl)
+import std/fs (fileExists, readFile)
+import std/env (getEnvOr)
+import std/json (Json, decode, get, getInt)
+import std/option (Option, Some, None)
+import std/result (Ok, Err)
 import src/core/types (Msg)
 
 export pure func estimate_tokens(msgs: [Msg], system: string) -> int =
@@ -16,53 +21,77 @@ pure func est0(system: string) -> int
   ]
   { estimate_tokens([], system) }
 
--- Flat dispatch without the "openrouter/" prefix. All branches return >= 0.
--- Split from context_limit_for to eliminate the recursive openrouter/ case
--- so Z3 can verify the non-negativity contract.
-pure func context_limit_base(model: string) -> int
+-- Broad provider-family fallback. Concrete model limits live in
+-- .motoko/model-catalog.json under context_limits so routine catalog updates do
+-- not require AILANG code changes.
+pure func context_limit_fallback_base(model: string) -> int
   ensures { result >= 0 }
   {
-    if model == "anthropic/claude-sonnet-4-6" then 200000
-    else if model == "anthropic/claude-sonnet-4-5" then 200000
-    else if model == "anthropic/claude-opus-4-6" then 200000
-    else if model == "anthropic/claude-opus-4-7" then 1000000
-    else if model == "anthropic/claude-haiku-4-5" then 200000
-    else if model == "openai/gpt-4o" then 128000
-    else if model == "openai/gpt-4o-mini" then 128000
-    else if model == "openai/gpt-5" then 400000
-    else if model == "gemini-2.5-flash" then 1000000
-    else if model == "gemini-2.5-pro" then 2000000
-    else if model == "google/gemini-2.5-flash" then 1000000
-    else if model == "google/gemini-2.5-pro" then 2000000
-    else if model == "z-ai/glm-5" then 128000
-    else if model == "minimax/minimax-m2.7" then 256000
-    else if model == "x-ai/grok-3" then 131072
-    else if model == "deepseek/deepseek-v4-pro" then 1000000
-    else if model == "deepseek/deepseek-v4-flash" then 1000000
-    else if model == "deepseek/deepseek-v4-flash:free" then 1000000
-    else if startsWith(model, "anthropic/") then 200000
+    if startsWith(model, "anthropic/") then 200000
     else if startsWith(model, "openai/") then 128000
     else if startsWith(model, "google/") then 1000000
+    else if startsWith(model, "gemini-") then 1000000
     else if startsWith(model, "deepseek/deepseek-v4") then 1000000
-    else if model == "test/tiny" then 100
     else 0
   }
 
 export pure func context_limit_for(model: string) -> int
   ensures { result >= 0 }
   tests [
-    ("anthropic/claude-sonnet-4-6",                 200000),
-    ("gemini-2.5-pro",                              2000000),
-    ("google/gemini-2.5-pro",                       2000000),
+    ("anthropic/some-future-model",                 200000),
+    ("gemini-new-model",                            1000000),
+    ("google/some-gemini-model",                    1000000),
     ("openrouter/anthropic/claude-sonnet-4-5",      200000),
-    ("openrouter/z-ai/glm-5",                       128000),
-    ("openrouter/openai/gpt-5",                     400000),
+    ("openrouter/openai/some-model",                128000),
     ("openrouter/whatever",                         0),
     ("totally-unknown",                             0)
   ]
   {
     if startsWith(model, "openrouter/") then
-      context_limit_base(substring(model, length("openrouter/"), length(model)))
+      context_limit_fallback_base(substring(model, length("openrouter/"), length(model)))
     else
-      context_limit_base(model)
+      context_limit_fallback_base(model)
   }
+
+func catalog_path() -> string ! {Env, FS} {
+  let explicit = getEnvOr("MOTOKO_MODELS_FILE", "");
+  if explicit != "" then explicit
+  else if fileExists(".motoko/model-catalog.json") then ".motoko/model-catalog.json"
+  else {
+    let repo = getEnvOr("MOTOKO_REPO", "");
+    if repo != "" then "${repo}/.motoko/model-catalog.json"
+    else ".motoko/model-catalog.json"
+  }
+}
+
+func lookup_context_limit(limits: Json, model: string) -> Option[int] {
+  match getInt(limits, model) {
+    Some(n) => if n > 0 then Some(n) else None,
+    None => {
+      if startsWith(model, "openrouter/") then {
+        let stripped = substring(model, length("openrouter/"), length(model));
+        match getInt(limits, stripped) {
+          Some(n) => if n > 0 then Some(n) else None,
+          None => None
+        }
+      } else None
+    }
+  }
+}
+
+export func catalog_context_limit_for(model: string) -> int ! {Env, FS} {
+  let path = catalog_path();
+  if not fileExists(path) then context_limit_for(model)
+  else {
+    match decode(readFile(path)) {
+      Err(_) => context_limit_for(model),
+      Ok(root) => match get(root, "context_limits") {
+        Some(limits) => match lookup_context_limit(limits, model) {
+          Some(n) => n,
+          None => context_limit_for(model)
+        },
+        None => context_limit_for(model)
+      }
+    }
+  }
+}

--- a/src/core/context_usage.ail
+++ b/src/core/context_usage.ail
@@ -21,36 +21,22 @@ pure func est0(system: string) -> int
   ]
   { estimate_tokens([], system) }
 
--- Broad provider-family fallback. Concrete model limits live in
--- .motoko/model-catalog.json under context_limits so routine catalog updates do
--- not require AILANG code changes.
-pure func context_limit_fallback_base(model: string) -> int
-  ensures { result >= 0 }
-  {
-    if startsWith(model, "anthropic/") then 200000
-    else if startsWith(model, "openai/") then 128000
-    else if startsWith(model, "google/") then 1000000
-    else if startsWith(model, "gemini-") then 1000000
-    else if startsWith(model, "deepseek/deepseek-v4") then 1000000
-    else 0
-  }
-
+-- Concrete model limits live in .motoko/model-catalog.json under
+-- context_limits. Without a readable catalog, unknown means "no limit known"
+-- so callers fail open instead of guessing provider-family windows in code.
 export pure func context_limit_for(model: string) -> int
   ensures { result >= 0 }
   tests [
-    ("anthropic/some-future-model",                 200000),
-    ("gemini-new-model",                            1000000),
-    ("google/some-gemini-model",                    1000000),
-    ("openrouter/anthropic/claude-sonnet-4-5",      200000),
-    ("openrouter/openai/some-model",                128000),
+    ("anthropic/some-future-model",                 0),
+    ("gemini-new-model",                            0),
+    ("google/some-gemini-model",                    0),
+    ("openrouter/anthropic/claude-sonnet-4-5",      0),
+    ("openrouter/openai/some-model",                0),
     ("openrouter/whatever",                         0),
     ("totally-unknown",                             0)
   ]
   {
-    if startsWith(model, "openrouter/") then
-      context_limit_fallback_base(substring(model, length("openrouter/"), length(model)))
-    else
-      context_limit_fallback_base(model)
+    0
   }
 
 func catalog_path() -> string ! {Env, FS} {

--- a/src/core/context_usage.ail
+++ b/src/core/context_usage.ail
@@ -30,6 +30,8 @@ pure func context_limit_base(model: string) -> int
     else if model == "openai/gpt-4o" then 128000
     else if model == "openai/gpt-4o-mini" then 128000
     else if model == "openai/gpt-5" then 400000
+    else if model == "gemini-2.5-flash" then 1000000
+    else if model == "gemini-2.5-pro" then 2000000
     else if model == "google/gemini-2.5-flash" then 1000000
     else if model == "google/gemini-2.5-pro" then 2000000
     else if model == "z-ai/glm-5" then 128000
@@ -50,6 +52,7 @@ export pure func context_limit_for(model: string) -> int
   ensures { result >= 0 }
   tests [
     ("anthropic/claude-sonnet-4-6",                 200000),
+    ("gemini-2.5-pro",                              2000000),
     ("google/gemini-2.5-pro",                       2000000),
     ("openrouter/anthropic/claude-sonnet-4-5",      200000),
     ("openrouter/z-ai/glm-5",                       128000),

--- a/src/core/rpc.ail
+++ b/src/core/rpc.ail
@@ -12,7 +12,7 @@ module src/core/rpc
 -- MIGRATION sprint plan + CHANGELOG.md and git log around 2026-05-06.
 
 import src/core/agent_loop_v2 (run_v2_with_conversation)
-import src/core/context_usage (context_limit_for)
+import src/core/context_usage (catalog_context_limit_for)
 import src/core/test/stub_step (LiveAI)
 import std/io     (println, exit)
 import std/json   (Json, encode, jo, ja, kv, js, jb, jnum)
@@ -98,11 +98,12 @@ func compute_budget_plan(
   hybrid_enabled: bool,
   step: int,
   settings: RunSettings
-) -> BudgetPlan ! {Env, IO, Clock} {
+) -> BudgetPlan ! {Env, IO, Clock, FS} {
   let max_steps = clamp_positive(settings.max_steps, 50);
   let verifier_mode = settings.verifier_mode;
   let base = default_budget_plan(max_steps, verifier_mode);
   let remaining = if base.total - step < 0 then 0 else base.total - step;
+  let context_limit = catalog_context_limit_for(model);
   let ctx = {
     task: task,
     step: step,
@@ -116,7 +117,7 @@ func compute_budget_plan(
     budget_remaining: remaining,
     history_slice: [],
     state_key: "core:ext:budget",
-    context_limit: context_limit_for(model)
+    context_limit: context_limit
   };
   let patched = dispatch_budget_plan(ext_runtime, ctx, base);
   clamp_budget_plan(patched, max_steps)
@@ -208,6 +209,7 @@ export func run_with_config(cfg: RuntimeConfig, inv: InvocationConfig) -> () ! {
   let remaining = budget.total;
   let system_with_agents = with_agents_context(raw_system, cwd);
   let system_with_hint = with_cache_hint(system_with_agents, hint);
+  let context_limit = catalog_context_limit_for(model);
   let system_ctx = {
     task: task,
     step: 0,
@@ -221,7 +223,7 @@ export func run_with_config(cfg: RuntimeConfig, inv: InvocationConfig) -> () ! {
     budget_remaining: remaining,
     history_slice: [],
     state_key: "core:ext:system",
-    context_limit: context_limit_for(model)
+    context_limit: context_limit
   };
   let system = dispatch_build_system_prompt(ext_runtime, system_ctx, system_with_hint);
 

--- a/src/core/test/integration_tests.ail
+++ b/src/core/test/integration_tests.ail
@@ -3,7 +3,7 @@ module src/core/test/integration_tests
 import std/string (repeat)
 import std/result (Result, Ok, Err)
 import std/ai (Message, ToolCall)
-import src/core/compaction (compact_step)
+import src/core/compaction (compact_step_with_limit)
 import src/core/test/stub_step (prose_step, tool_step, scripted_to_step_result, terminal_step)
 
 -- Test 1: Cost-budget exhaustion math.
@@ -20,11 +20,10 @@ pure func test_cost_budget_exhausted() -> bool
     step_cost * 3 < 50000 && step_cost * 4 >= 50000
   }
 
--- Test 2: Context exhaustion with test/tiny model.
--- test/tiny has context_limit_for = 100 tokens.
+-- Test 2: Context exhaustion with an explicit tiny test limit.
 -- A 380-char tool message + 4-char user message = 384 chars total.
 -- estimate_tokens_messages: (384 + 3) / 4 = 96 tokens → usage = 96% >= 95%.
--- compact_step returns Err("compaction_exhausted: ...") at >= 95%.
+-- compact_step_with_limit returns Err("compaction_exhausted: ...") at >= 95%.
 pure func test_compaction_fires_above_70pct() -> bool
   tests [((), true)]
   {
@@ -40,7 +39,7 @@ pure func test_compaction_fires_above_70pct() -> bool
       tool_calls: [],
       tool_call_id: ""
     };
-    match compact_step([user_msg, big_msg], "test/tiny") {
+    match compact_step_with_limit([user_msg, big_msg], "test/tiny", 100) {
       Err(_) => true,
       Ok(_)  => false
     }

--- a/src/tui/src/index.ts
+++ b/src/tui/src/index.ts
@@ -26,6 +26,7 @@ import { RuntimeProcess, resolveDelegatedExec } from "./runtime-process.js";
 import { AgentUI, parseScratchpadCellsJson } from "./ui.js";
 import { SessionLogger } from "./session-logger.js";
 import { activeProfile } from "./config.js";
+import { resolveRuntimeModel } from "./models.js";
 import type { AgentEvent, DelegatedCall } from "./runtime-process.js";
 import type { ScratchpadCellResult } from "./scratchpad/frames.js";
 
@@ -256,7 +257,10 @@ function applyClickStackProfileConfig(
   clickstack: ProfileAgentConfig["clickstack"],
   protectedKeys: Set<string>,
 ): void {
-  if (!clickstack?.enabled) return;
+  if (!clickstack?.enabled) {
+    disableOtelExport();
+    return;
+  }
   // ClickStack/HyperDX rejects OTLP ingestion without an authorization header,
   // so without a key the AILANG runtime would emit `traces export: failed to
   // send ... 401 (missing or empty authorization header)` on every span. The
@@ -289,13 +293,12 @@ function clickStackAuthHeaderPresent(): boolean {
   return /authorization\s*=/i.test(headers);
 }
 
-// Prevent every AILANG child (the version probe and the agent runtime) from
-// attempting trace export. AILANG only initializes its OTLP exporter when
-// OTEL_EXPORTER_OTLP_ENDPOINT is set — and crucially AILANG_TRACE=off does NOT
-// stop it, only removing the endpoint does. The endpoint is injected into the
-// process env by docker-compose (observability stack), so deleting it here is
-// the only reliable way to silence export. The version probe inherits
-// process.env directly; the runtime is additionally gated on MOTOKO_OTEL.
+// Prevent AILANG children (the version probe and the agent runtime) from
+// attempting trace export unless the selected profile explicitly enables
+// ClickStack. AILANG initializes its OTLP exporter when
+// OTEL_EXPORTER_OTLP_ENDPOINT is set, and AILANG_TRACE=off does not stop it.
+// The endpoint can be inherited from docker-compose or the shell, so deleting
+// it here is the only reliable way to keep normal runs quiet.
 function disableOtelExport(): void {
   delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
   delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
@@ -751,10 +754,10 @@ async function main(): Promise<void> {
   const profileAgent = resolveProfileAgentConfig(workdir, profile);
   applyToolProfileConfig(profileAgent, shellEnvKeys);
   applyClickStackProfileConfig(profileAgent.clickstack, shellEnvKeys);
-  const model =
-    process.env.MODEL ??
-    profileAgent.model ??
-    "anthropic/claude-sonnet-4-6";
+  const model = resolveRuntimeModel(process.env, profileAgent.model);
+  // Publish the resolved runtime model once so helper paths (env-server,
+  // scratchpad, subagents) observe the same default as the AILANG runtime.
+  process.env.MODEL = model;
   const systemPrompt = systemPromptForWorkspace(projectRoot, workdir);
   const openaiBaseUrl = process.env.OPENAI_BASE_URL ?? profileAgent.openaiBaseUrl ?? "";
   const aiOptionsJson = process.env.MOTOKO_AI_OPTIONS_JSON ?? profileAgent.aiOptionsJson ?? "";
@@ -844,7 +847,10 @@ async function main(): Promise<void> {
     const logger = new SessionLogger(projectRoot, pkgVersion);
     sessionLogger = logger;
     logger.logUserInput(task);
-    ui.onModelChange = (newModel) => runtimeProcess!.setModel(newModel);
+    ui.onModelChange = (newModel) => {
+      process.env.MODEL = newModel;
+      runtimeProcess!.setModel(newModel);
+    };
     ui.onAbort = () => runtimeProcess!.abort();
     ui.onUserMessage = (content) => {
       logger.logUserInput(content);
@@ -949,7 +955,10 @@ async function main(): Promise<void> {
     ui.runtimeProcess = runtimeProcess;
   }
 
-  ui.onModelChange = (newModel) => runtimeProcess?.setModel(newModel);
+  ui.onModelChange = (newModel) => {
+    process.env.MODEL = newModel;
+    runtimeProcess?.setModel(newModel);
+  };
   ui.onUserMessage = (content) => {
     sessionLogger?.logUserInput(content);
     runtimeProcess?.sendUserMessage(content);

--- a/src/tui/src/index.ts
+++ b/src/tui/src/index.ts
@@ -238,6 +238,10 @@ function nonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() !== "" ? value : undefined;
 }
 
+function envOrProfileString(envKey: string, profileValue: string | undefined): string {
+  return nonEmptyString(process.env[envKey]) ?? profileValue ?? "";
+}
+
 function positiveNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? value
@@ -707,9 +711,10 @@ async function main(): Promise<void> {
   // the agent name instead of the underlying runtime ("bun.exe" /
   // "node"). OSC 0 sets both icon and window title; ST is BEL (\x07) for
   // maximal compatibility (some terminals don't recognise ST = \x1b\\).
-  // Skip when TTY detection fails (piped output, JSONL mode) so we don't
-  // pollute log streams with the escape bytes.
-  if (process.stdout.isTTY && process.env.MOTOKO_JSONL_OUTPUT !== "1") {
+  // Skip in non-interactive output modes so we don't pollute log streams with
+  // escape bytes.
+  const headlessOutput = process.env.MOTOKO_HEADLESS === "1";
+  if (process.stdout.isTTY && process.env.MOTOKO_JSONL_OUTPUT !== "1" && !headlessOutput) {
     process.stdout.write("\x1b]0;[λ] motoko\x07");
   }
 
@@ -759,8 +764,8 @@ async function main(): Promise<void> {
   // scratchpad, subagents) observe the same default as the AILANG runtime.
   process.env.MODEL = model;
   const systemPrompt = systemPromptForWorkspace(projectRoot, workdir);
-  const openaiBaseUrl = process.env.OPENAI_BASE_URL ?? profileAgent.openaiBaseUrl ?? "";
-  const aiOptionsJson = process.env.MOTOKO_AI_OPTIONS_JSON ?? profileAgent.aiOptionsJson ?? "";
+  const openaiBaseUrl = envOrProfileString("OPENAI_BASE_URL", profileAgent.openaiBaseUrl);
+  const aiOptionsJson = envOrProfileString("MOTOKO_AI_OPTIONS_JSON", profileAgent.aiOptionsJson);
 
   let brainVersion = "unknown";
   try {
@@ -791,7 +796,7 @@ async function main(): Promise<void> {
   } catch {}
 
   // Future improvement: regenerate/reflow banner on terminal resize events.
-  if (!jsonlOutput) {
+  if (!jsonlOutput && !headlessOutput) {
     const bannerLines = renderBanner({ columns: process.stdout.columns });
     process.stdout.write(
       bannerLines.join("\n") +
@@ -820,9 +825,13 @@ async function main(): Promise<void> {
   // CI is NOT treated as a TUI blocker — devcontainers and CI runners
   // often set CI=1 even when the user is running interactively.
   const isTTY =
-    Boolean(process.stdout.isTTY) ||
-    Boolean(process.stdout.columns) ||
-    Boolean(process.env.FORCE_TTY);
+    !headlessOutput &&
+    !jsonlOutput &&
+    (
+      Boolean(process.stdout.isTTY) ||
+      Boolean(process.stdout.columns) ||
+      Boolean(process.env.FORCE_TTY)
+    );
 
   // runtime process handle is declared mutable because abort()/setModel() fire from
   // callbacks, and spawnRuntimeProcess() may be called again on model switch.

--- a/src/tui/src/models.test.ts
+++ b/src/tui/src/models.test.ts
@@ -72,12 +72,20 @@ describe("loadModelsConfig", () => {
     const { env, cleanup } = withTempModelsConfig({
       known_models: ["gemini-2.5-flash", "google/gemini-2.5-flash", ""],
       openrouter_fallback_models: ["openrouter/google/gemini-2.5-flash"],
+      context_limits: {
+        "gemini-2.5-flash": 1000000,
+        "ignored-zero": 0,
+        "ignored-string": "100",
+      },
     });
     try {
       expect(resolveModelsConfigPath(env)).toBe(env.MOTOKO_MODELS_FILE);
       expect(loadModelsConfig(env)).toEqual({
         known_models: ["gemini-2.5-flash", "google/gemini-2.5-flash"],
         openrouter_fallback_models: ["openrouter/google/gemini-2.5-flash"],
+        context_limits: {
+          "gemini-2.5-flash": 1000000,
+        },
       });
     } finally {
       cleanup();
@@ -91,6 +99,7 @@ describe("loadModelsConfig", () => {
 
     expect(directGoogleModels.length).toBeGreaterThan(0);
     expect(openRouterGoogleModels).toEqual([]);
+    expect(config.context_limits["gemini-2.5-flash"]).toBeGreaterThan(0);
   });
 });
 

--- a/src/tui/src/models.test.ts
+++ b/src/tui/src/models.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
 import {
+  DEFAULT_RUNTIME_MODEL,
   fetchDynamicModelsFromEnv,
   fetchLocalOpenAIModels,
+  loadModelsConfig,
   mergeUniqueModels,
   normalizeOpenAIBaseURL,
+  resolveRuntimeModel,
+  resolveModelsConfigPath,
 } from "./models.js";
 
 describe("normalizeOpenAIBaseURL", () => {
@@ -32,6 +39,58 @@ describe("mergeUniqueModels", () => {
       ["openai/gpt-4o", "openai/b"],
     );
     expect(merged).toEqual(["openai/gpt-4o", "openai/a", "openrouter/x", "openai/b"]);
+  });
+});
+
+describe("resolveRuntimeModel", () => {
+  it("uses MODEL env over profile model", () => {
+    expect(resolveRuntimeModel({ MODEL: "openai/gpt-4o" }, "anthropic/claude-sonnet-4-6")).toBe("openai/gpt-4o");
+  });
+
+  it("uses profile model when MODEL env is empty", () => {
+    expect(resolveRuntimeModel({}, "gemini-2.5-flash")).toBe("gemini-2.5-flash");
+    expect(resolveRuntimeModel({ MODEL: "   " }, "openrouter/auto")).toBe("openrouter/auto");
+  });
+
+  it("falls back to the default runtime model", () => {
+    expect(resolveRuntimeModel({}, "")).toBe(DEFAULT_RUNTIME_MODEL);
+  });
+});
+
+function withTempModelsConfig(config: unknown): { env: NodeJS.ProcessEnv; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "motoko-models-"));
+  const filePath = path.join(dir, "model-catalog.json");
+  writeFileSync(filePath, JSON.stringify(config), "utf8");
+  return {
+    env: { MOTOKO_MODELS_FILE: filePath },
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("loadModelsConfig", () => {
+  it("loads known models and OpenRouter fallback models from JSON", () => {
+    const { env, cleanup } = withTempModelsConfig({
+      known_models: ["gemini-2.5-flash", "google/gemini-2.5-flash", ""],
+      openrouter_fallback_models: ["openrouter/google/gemini-2.5-flash"],
+    });
+    try {
+      expect(resolveModelsConfigPath(env)).toBe(env.MOTOKO_MODELS_FILE);
+      expect(loadModelsConfig(env)).toEqual({
+        known_models: ["gemini-2.5-flash", "google/gemini-2.5-flash"],
+        openrouter_fallback_models: ["openrouter/google/gemini-2.5-flash"],
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("keeps direct Google/Vertex entries out of the OpenRouter google/ namespace", () => {
+    const config = loadModelsConfig({});
+    const directGoogleModels = config.known_models.filter((model) => model.startsWith("gemini-"));
+    const openRouterGoogleModels = config.known_models.filter((model) => model.startsWith("google/"));
+
+    expect(directGoogleModels.length).toBeGreaterThan(0);
+    expect(openRouterGoogleModels).toEqual([]);
   });
 });
 
@@ -70,6 +129,10 @@ describe("fetchDynamicModelsFromEnv", () => {
   });
 
   it("merges known + local + openrouter and dedupes", async () => {
+    const { env: modelEnv, cleanup } = withTempModelsConfig({
+      known_models: ["openai/gpt-4o", "gemini-2.5-flash"],
+      openrouter_fallback_models: ["openrouter/fallback/model"],
+    });
     const mockFetch = jest.fn(async (input: unknown) => {
       const url = String(input);
       if (url.includes("/v1/models") && url.includes("127.0.0.1")) {
@@ -88,14 +151,39 @@ describe("fetchDynamicModelsFromEnv", () => {
     });
     (globalThis as { fetch?: unknown }).fetch = mockFetch;
 
-    const models = await fetchDynamicModelsFromEnv({
-      OPENAI_BASE_URL: "http://127.0.0.1:8000",
-      OPENROUTER_API_KEY: "test-key",
-    });
+    try {
+      const models = await fetchDynamicModelsFromEnv({
+        ...modelEnv,
+        OPENAI_BASE_URL: "http://127.0.0.1:8000",
+        OPENROUTER_API_KEY: "test-key",
+      });
 
-    expect(models).toContain("openai/google/gemma-4-26B-A4B-it");
-    // Already in KNOWN_MODELS; should not duplicate.
-    expect(models.filter((m) => m === "openai/gpt-4o")).toHaveLength(1);
-    expect(models).toContain("openrouter/meta-llama/llama-3.3-70b-instruct");
+      expect(models).toContain("openai/google/gemma-4-26B-A4B-it");
+      // Already in configured known models; should not duplicate.
+      expect(models.filter((m) => m === "openai/gpt-4o")).toHaveLength(1);
+      expect(models).toContain("openrouter/meta-llama/llama-3.3-70b-instruct");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("uses configured OpenRouter fallback models when the live fetch fails", async () => {
+    const { env: modelEnv, cleanup } = withTempModelsConfig({
+      known_models: ["gemini-2.5-flash"],
+      openrouter_fallback_models: ["openrouter/fallback/model"],
+    });
+    const mockFetch = jest.fn(async () => ({ ok: false }));
+    (globalThis as { fetch?: unknown }).fetch = mockFetch;
+
+    try {
+      const models = await fetchDynamicModelsFromEnv({
+        ...modelEnv,
+        OPENROUTER_API_KEY: "test-key",
+      });
+
+      expect(models).toEqual(["gemini-2.5-flash", "openrouter/fallback/model"]);
+    } finally {
+      cleanup();
+    }
   });
 });

--- a/src/tui/src/models.ts
+++ b/src/tui/src/models.ts
@@ -21,6 +21,7 @@ import { fileURLToPath } from "url";
 export type ModelsConfig = {
   known_models: string[];
   openrouter_fallback_models: string[];
+  context_limits: Record<string, number>;
 };
 
 export const DEFAULT_RUNTIME_MODEL = "anthropic/claude-sonnet-4-6";
@@ -28,6 +29,7 @@ export const DEFAULT_RUNTIME_MODEL = "anthropic/claude-sonnet-4-6";
 const EMPTY_MODELS_CONFIG: ModelsConfig = {
   known_models: [],
   openrouter_fallback_models: [],
+  context_limits: {},
 };
 
 export function resolveRuntimeModel(
@@ -48,14 +50,27 @@ function stringArrayField(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
 }
 
+function positiveNumberRecordField(value: unknown): Record<string, number> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const out: Record<string, number> = {};
+  for (const [key, limit] of Object.entries(value)) {
+    if (typeof limit === "number" && Number.isFinite(limit) && limit > 0) {
+      out[key] = limit;
+    }
+  }
+  return out;
+}
+
 function parseModelsConfig(raw: string): ModelsConfig {
   const parsed = JSON.parse(raw) as {
     known_models?: unknown;
     openrouter_fallback_models?: unknown;
+    context_limits?: unknown;
   };
   return {
     known_models: stringArrayField(parsed.known_models),
     openrouter_fallback_models: stringArrayField(parsed.openrouter_fallback_models),
+    context_limits: positiveNumberRecordField(parsed.context_limits),
   };
 }
 

--- a/src/tui/src/models.ts
+++ b/src/tui/src/models.ts
@@ -1,36 +1,95 @@
 // tui/src/models.ts
 //
-// Canonical list of known model identifiers shown in the /model SelectList.
-// Format: "provider/model-name" — matches what AILANG passes to --ai.
+// Load the baseline model identifiers shown in the /model SelectList.
+// Motoko keeps provider-like routing prefixes for most providers, but direct
+// Google Gemini / Vertex uses bare "gemini-*" ids. In AILANG, "google/..."
+// means an OpenRouter vendor/model id, not the direct Google provider.
+//
+// Static model ids live in .motoko/model-catalog.json so provider/catalog updates do
+// not require TypeScript changes. Set MOTOKO_MODELS_FILE to point at an
+// alternate JSON file.
 //
 // OpenRouter models are prefixed with "openrouter/" and can be fetched live
 // from the OpenRouter API when OPENROUTER_API_KEY is set.
 // Local OpenAI-compatible models are prefixed with "openai/" and fetched from
 // OPENAI_BASE_URL when set.
 
-export const KNOWN_MODELS: string[] = [
-  "anthropic/claude-sonnet-4-6",
-  "anthropic/claude-opus-4-6",
-  "anthropic/claude-haiku-4-5",
-  "openai/gpt-4o",
-  "openai/gpt-4o-mini",
-  "google/gemini-2.5-flash",
-  "google/gemini-2.5-pro",
-];
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 
-// Static fallback shown when OPENROUTER_API_KEY is set but the live fetch fails.
-export const OPENROUTER_FALLBACK_MODELS: string[] = [
-  "openrouter/anthropic/claude-sonnet-4-5",
-  "openrouter/anthropic/claude-opus-4-5",
-  "openrouter/openai/gpt-4o",
-  "openrouter/openai/gpt-4o-mini",
-  "openrouter/google/gemini-2.5-pro",
-  "openrouter/google/gemini-2.5-flash",
-  "openrouter/meta-llama/llama-3.3-70b-instruct",
-  "openrouter/mistralai/mixtral-8x7b-instruct",
-  "openrouter/deepseek/deepseek-r1",
-  "openrouter/qwen/qwen-2.5-72b-instruct",
-];
+export type ModelsConfig = {
+  known_models: string[];
+  openrouter_fallback_models: string[];
+};
+
+export const DEFAULT_RUNTIME_MODEL = "anthropic/claude-sonnet-4-6";
+
+const EMPTY_MODELS_CONFIG: ModelsConfig = {
+  known_models: [],
+  openrouter_fallback_models: [],
+};
+
+export function resolveRuntimeModel(
+  env: NodeJS.ProcessEnv = process.env,
+  profileModel?: string,
+): string {
+  const envModel = (env["MODEL"] ?? "").trim();
+  if (envModel !== "") return envModel;
+
+  const configuredModel = (profileModel ?? "").trim();
+  if (configuredModel !== "") return configuredModel;
+
+  return DEFAULT_RUNTIME_MODEL;
+}
+
+function stringArrayField(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function parseModelsConfig(raw: string): ModelsConfig {
+  const parsed = JSON.parse(raw) as {
+    known_models?: unknown;
+    openrouter_fallback_models?: unknown;
+  };
+  return {
+    known_models: stringArrayField(parsed.known_models),
+    openrouter_fallback_models: stringArrayField(parsed.openrouter_fallback_models),
+  };
+}
+
+function defaultModelsConfigCandidates(): string[] {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return [
+    path.join(process.cwd(), ".motoko", "model-catalog.json"),
+    path.resolve(here, "..", "..", "..", ".motoko", "model-catalog.json"),
+  ];
+}
+
+export function resolveModelsConfigPath(env: NodeJS.ProcessEnv = process.env): string | null {
+  const explicit = (env["MOTOKO_MODELS_FILE"] ?? "").trim();
+  if (explicit) {
+    return path.resolve(explicit);
+  }
+
+  for (const candidate of defaultModelsConfigCandidates()) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function loadModelsConfig(env: NodeJS.ProcessEnv = process.env): ModelsConfig {
+  const filePath = resolveModelsConfigPath(env);
+  if (!filePath) return EMPTY_MODELS_CONFIG;
+  try {
+    return parseModelsConfig(readFileSync(filePath, "utf8"));
+  } catch {
+    return EMPTY_MODELS_CONFIG;
+  }
+}
 
 /**
  * Normalize OPENAI_BASE_URL for local OpenAI-compatible endpoints.
@@ -83,9 +142,9 @@ export function mergeUniqueModels(...lists: string[][]): string[] {
 
 /**
  * Fetch the live model list from OpenRouter and return model ids prefixed
- * with "openrouter/".  Falls back to OPENROUTER_FALLBACK_MODELS on error.
+ * with "openrouter/". Falls back to the configured OpenRouter models on error.
  */
-export async function fetchOpenRouterModels(apiKey: string): Promise<string[]> {
+export async function fetchOpenRouterModels(apiKey: string, fallbackModels: string[] = []): Promise<string[]> {
   try {
     const res = await fetch("https://openrouter.ai/api/v1/models", {
       headers: {
@@ -93,15 +152,15 @@ export async function fetchOpenRouterModels(apiKey: string): Promise<string[]> {
       },
     });
     if (!res.ok) {
-      return OPENROUTER_FALLBACK_MODELS;
+      return fallbackModels;
     }
     const json = (await res.json()) as { data?: Array<{ id: string }> };
     if (!Array.isArray(json.data)) {
-      return OPENROUTER_FALLBACK_MODELS;
+      return fallbackModels;
     }
     return json.data.map((m) => `openrouter/${m.id}`);
   } catch {
-    return OPENROUTER_FALLBACK_MODELS;
+    return fallbackModels;
   }
 }
 
@@ -134,11 +193,12 @@ export async function fetchDynamicModelsFromEnv(
 ): Promise<string[]> {
   const openRouterKey = env["OPENROUTER_API_KEY"] ?? "";
   const openAIBaseURL = env["OPENAI_BASE_URL"] ?? "";
+  const modelsConfig = loadModelsConfig(env);
 
   const [localOpenAIModels, openRouterModels] = await Promise.all([
     openAIBaseURL ? fetchLocalOpenAIModels(openAIBaseURL) : Promise.resolve([]),
-    openRouterKey ? fetchOpenRouterModels(openRouterKey) : Promise.resolve([]),
+    openRouterKey ? fetchOpenRouterModels(openRouterKey, modelsConfig.openrouter_fallback_models) : Promise.resolve([]),
   ]);
 
-  return mergeUniqueModels(KNOWN_MODELS, localOpenAIModels, openRouterModels);
+  return mergeUniqueModels(modelsConfig.known_models, localOpenAIModels, openRouterModels);
 }

--- a/src/tui/src/runtime-process.stream-protocol.test.ts
+++ b/src/tui/src/runtime-process.stream-protocol.test.ts
@@ -46,8 +46,8 @@ describe("stream protocol decoder", () => {
 
 describe("providerSelectionModel", () => {
   it("routes local OpenAI-compatible Motoko ids through AILANG's OpenAI provider", () => {
-    expect(providerSelectionModel("openai/deepseek-v4-flash", "http://127.0.0.1:8000/v1")).toBe("gpt-4o");
-    expect(providerSelectionModel("deepseek-v4-flash", "http://127.0.0.1:8000/v1")).toBe("gpt-4o");
+    expect(providerSelectionModel("openai/deepseek-v4-flash", "http://127.0.0.1:8000/v1")).toBe("gpt5");
+    expect(providerSelectionModel("deepseek-v4-flash", "http://127.0.0.1:8000/v1")).toBe("gpt5");
   });
 
   it("strips Motoko direct-provider prefixes before AILANG provider guessing", () => {

--- a/src/tui/src/runtime-process.stream-protocol.test.ts
+++ b/src/tui/src/runtime-process.stream-protocol.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
-import { parseAgentEventLine } from "./runtime-process.js";
+import { normalizeRuntimeWarning, parseAgentEventLine, providerSelectionModel } from "./runtime-process.js";
 
 describe("stream protocol decoder", () => {
   it("parses context usage events", () => {
@@ -41,5 +41,35 @@ describe("stream protocol decoder", () => {
     expect(parseAgentEventLine("")).toBeNull();
     expect(parseAgentEventLine("not-json")).toBeNull();
     expect(parseAgentEventLine('{"foo":"bar"}')).toBeNull();
+  });
+});
+
+describe("providerSelectionModel", () => {
+  it("routes local OpenAI-compatible Motoko ids through AILANG's OpenAI provider", () => {
+    expect(providerSelectionModel("openai/deepseek-v4-flash", "http://127.0.0.1:8000/v1")).toBe("gpt-4o");
+    expect(providerSelectionModel("deepseek-v4-flash", "http://127.0.0.1:8000/v1")).toBe("gpt-4o");
+  });
+
+  it("strips Motoko direct-provider prefixes before AILANG provider guessing", () => {
+    expect(providerSelectionModel("openai/gpt-4o", "")).toBe("gpt-4o");
+    expect(providerSelectionModel("anthropic/claude-sonnet-4-6", "")).toBe("claude-sonnet-4-6");
+    expect(providerSelectionModel("google/gemini-2.5-flash", "")).toBe("gemini-2.5-flash");
+  });
+
+  it("preserves explicit OpenRouter and Ollama routing ids", () => {
+    expect(providerSelectionModel("openrouter/openai/gpt-4o", "")).toBe("openrouter/openai/gpt-4o");
+    expect(providerSelectionModel("openrouter/auto", "")).toBe("openrouter/auto");
+    expect(providerSelectionModel("ollama/llama3.2", "")).toBe("ollama/llama3.2");
+  });
+});
+
+describe("normalizeRuntimeWarning", () => {
+  it("strips duplicated warning prefixes", () => {
+    expect(normalizeRuntimeWarning("Warning: Warning: something happened")).toBe("something happened");
+  });
+
+  it("drops expected local runtime informational noise", () => {
+    expect(normalizeRuntimeWarning("Warning: stdlib version mismatch: expected dev, found v0.25.0 at /tmp/std")).toBeNull();
+    expect(normalizeRuntimeWarning("[ai] cache_hint_ignored_openai_auto_cache: provider observed Request.CacheBreakpoints")).toBeNull();
   });
 });

--- a/src/tui/src/runtime-process.ts
+++ b/src/tui/src/runtime-process.ts
@@ -122,9 +122,11 @@ export function providerSelectionModel(model: string, openaiBaseUrl: string): st
 
   // For local OpenAI-compatible endpoints, unknown model ids like
   // "deepseek-v4-flash" do not let AILANG infer the OpenAI provider. Use a
-  // known OpenAI-shaped selector for --ai; stepWithStream still sends the real
-  // local model id.
-  if (openaiBaseUrl.trim() !== "") return "gpt-4o";
+  // configured OpenAI selector for --ai; stepWithStream still sends the real
+  // local model id. Use the AILANG model alias ("gpt5"), not the provider API
+  // id ("gpt-5"), so AILANG takes the configured-model path that honors
+  // OPENAI_BASE_URL.
+  if (openaiBaseUrl.trim() !== "") return "gpt5";
 
   // AILANG's --ai provider guessing treats vendor/model strings such as
   // "openai/..." and "anthropic/..." as OpenRouter vendor ids. Motoko uses

--- a/src/tui/src/runtime-process.ts
+++ b/src/tui/src/runtime-process.ts
@@ -114,6 +114,47 @@ export function parseAgentEventLine(line: string): AgentEvent | null {
   }
 }
 
+export function providerSelectionModel(model: string, openaiBaseUrl: string): string {
+  const trimmed = model.trim();
+  if (trimmed === "openrouter/auto") return trimmed;
+  if (trimmed.startsWith("openrouter/")) return trimmed;
+  if (trimmed.startsWith("ollama/") || trimmed.startsWith("ollama:")) return trimmed;
+
+  // For local OpenAI-compatible endpoints, unknown model ids like
+  // "deepseek-v4-flash" do not let AILANG infer the OpenAI provider. Use a
+  // known OpenAI-shaped selector for --ai; stepWithStream still sends the real
+  // local model id.
+  if (openaiBaseUrl.trim() !== "") return "gpt-4o";
+
+  // AILANG's --ai provider guessing treats vendor/model strings such as
+  // "openai/..." and "anthropic/..." as OpenRouter vendor ids. Motoko uses
+  // those prefixes as direct-provider UI/profile routing ids, so strip them
+  // before provider selection. The step call separately receives the same
+  // stripped API model id from provider_api_model().
+  for (const prefix of ["openai/", "anthropic/", "google/"]) {
+    if (trimmed.startsWith(prefix)) {
+      const bare = trimmed.slice(prefix.length);
+      return bare.length > 0 ? bare : trimmed;
+    }
+  }
+
+  return trimmed;
+}
+
+export function normalizeRuntimeWarning(line: string): string | null {
+  let message = line.trim();
+  if (!message) return null;
+
+  while (message.toLowerCase().startsWith("warning:")) {
+    message = message.slice("warning:".length).trim();
+  }
+
+  if (message.includes("stdlib version mismatch:")) return null;
+  if (message.includes("cache_hint_ignored_")) return null;
+
+  return message.length > 0 ? message : null;
+}
+
 export function runDelegatedCallsSequential(
   calls: DelegatedCall[],
   runner: (call: DelegatedCall) => DelegatedResult,
@@ -292,7 +333,7 @@ export class RuntimeProcess {
   ) {
     this.workdir = workdir;
     this.onEvent = onEvent;
-    const aiModelArg = model;
+    const aiModelArg = providerSelectionModel(model, openaiBaseUrl);
     const ailangBin = (process.env.AILANG_BIN && process.env.AILANG_BIN.trim() !== "")
       ? process.env.AILANG_BIN
       : "ailang";
@@ -306,6 +347,7 @@ export class RuntimeProcess {
       EXA_API_KEY: process.env.EXA_API_KEY,
       CLICKSTACK_INGESTION_KEY: process.env.CLICKSTACK_INGESTION_KEY,
       AILANG_FS_SANDBOX: workdir,
+      AILANG_NO_VERSION_WARNINGS: process.env.AILANG_NO_VERSION_WARNINGS ?? "1",
       MOTOKO_STREAM_EVENTS: process.env.MOTOKO_STREAM_EVENTS ?? "1",
       // M-MOTOKO-HEADLESS (2026-05-08): when stdin is not a TTY, set
       // MOTOKO_HEADLESS=1 so the AILANG runtime's conversation_loop_v2
@@ -504,7 +546,7 @@ export class RuntimeProcess {
       crlfDelay: Infinity,
     });
     stderrRl.on("line", (line) => {
-      const message = line.trim();
+      const message = normalizeRuntimeWarning(line);
       if (!message) return;
       this.onEvent({ type: "warning", message });
     });

--- a/src/tui/src/runtime-process.ts
+++ b/src/tui/src/runtime-process.ts
@@ -479,7 +479,7 @@ export class RuntimeProcess {
       ],
       {
         env: childEnv,
-        stdio: ["pipe", "pipe", "inherit"],
+        stdio: ["pipe", "pipe", "pipe"],
       }
     );
 
@@ -499,8 +499,19 @@ export class RuntimeProcess {
       }
     });
 
+    const stderrRl = readline.createInterface({
+      input: this.proc.stderr!,
+      crlfDelay: Infinity,
+    });
+    stderrRl.on("line", (line) => {
+      const message = line.trim();
+      if (!message) return;
+      this.onEvent({ type: "warning", message });
+    });
+
     this.proc.on("exit", () => {
       this.dead = true;
+      stderrRl.close();
       onExit();
     });
   }


### PR DESCRIPTION
# Fix Local Model Routing

Base branch: `origin/main`

## Summary

This branch fixes Motoko model routing so local OpenAI-compatible models are
not accidentally sent through OpenRouter, while preserving the selected Motoko
model string for UI state, profile state, context telemetry, and follow-up
turns.

The previous routing path passed Motoko's UI/profile identifiers directly to
AILANG provider selection and then partially stripped prefixes before
`std/ai.step()`. That made local models such as
`openai/deepseek-v4-flash` or `openai/google/gemma-4-26B-A4B-it` ambiguous:
the prefix was useful to Motoko, but AILANG could interpret slashful vendor
strings as OpenRouter routing ids.

## Changes

- Add a two-stage model routing split:
  - the TUI launcher maps Motoko model ids to an AILANG `--ai` provider
    selector with `providerSelectionModel`
  - the AILANG runtime maps Motoko model ids to provider API model ids with
    `provider_api_model`
- Route local OpenAI-compatible runs through AILANG's OpenAI provider when
  `OPENAI_BASE_URL` is set, while still sending the actual local model id to
  the provider request.
- Preserve explicit OpenRouter routing ids, including `openrouter/auto`, and
  strip only the outer `openrouter/` prefix for pinned OpenRouter
  vendor/model ids before the provider API call.
- Strip Motoko direct-provider prefixes for direct OpenAI, Anthropic, and
  Google model requests before AILANG provider guessing and before
  `std/ai.step()`.
- Move the static model picker catalog and known context windows into
  `.motoko/model-catalog.json`, with `MOTOKO_MODELS_FILE` support for custom
  catalogs.
- Preserve newer model context windows, such as
  `ollama/qwen3.6:35b-a3b-mxfp8`, as catalog entries rather than hardcoded
  AILANG branches.
- Update context usage, budget planning, extension context, and structural
  compaction to read catalog-backed context limits. Unknown or uncatalogued
  models have no known limit, so compaction is skipped rather than guessed from
  provider-family prefixes.
- Resolve the runtime model consistently as:
  `MODEL` env var > profile `agent.model` > `anthropic/claude-sonnet-4-6`,
  then publish the resolved value back to `process.env.MODEL` so helper paths
  observe the same model.
- Update the local profile defaults to use `openai/deepseek-v4-flash` against
  the configured local OpenAI-compatible endpoint.
- Document Motoko model identifier semantics in the README, including the
  difference between direct Gemini ids and OpenRouter `google/...` vendor ids.
- Capture AILANG runtime stderr as structured warning events, suppressing known
  local informational noise such as stdlib version mismatch and cache-hint
  warnings.
- Add focused tests for runtime model resolution, catalog loading, OpenRouter
  fallback models, local OpenAI model discovery, provider selection, warning
  normalization, and AILANG-side provider API model conversion.

## User Impact

- Local OpenAI-compatible profiles can select local model ids with the
  `openai/` Motoko routing prefix without leaking those requests to
  OpenRouter.
- Slashful local model ids are preserved after the `openai/` routing prefix is
  removed, so ids like `google/gemma-4-26B-A4B-it` still reach the local
  endpoint correctly.
- Direct Gemini / Vertex usage is clearer: use bare `gemini-*` ids for direct
  Google routing, and `openrouter/google/...` for OpenRouter.
- The `/model` picker can be updated through JSON catalog data instead of
  TypeScript edits.
- Context counters and compaction use the same catalog-backed model limits as
  the TUI model catalog.

## Verification

- `make -n build`
  - Confirms build, sync, lock, extension boot, and core check commands use
    upstream `ailang` from PATH.
- `ailang check src/core/context_usage.ail`
  - Passes.
- `ailang test src/core/context_usage.ail`
  - Passes: 11 tests.
- `jq empty .motoko/model-catalog.json`
  - Passes.
- `jq -e '.context_limits["ollama/qwen3.6:35b-a3b-mxfp8"] == 262144' .motoko/model-catalog.json`
  - Passes.
- `ailang check scripts/smoke_catalog_compaction.ail`
  - Passes.
- `ailang run --caps IO,FS,Env --entry main scripts/smoke_catalog_compaction.ail`
  - Passes and confirms:
    - `catalog_context_limit_for("test/tiny")` reads the checked-in catalog
      limit of `100`.
    - `compact_step_with_limit` reports `compaction_exhausted` when that
      catalog limit is exceeded by non-elidable history.
    - uncatalogued provider-prefixed models resolve to `0` instead of a
      guessed provider-family limit.
- `cd src/tui && bun run build`
  - Passes.
- `cd src/tui && bun run test -- src/models.test.ts src/runtime-process.stream-protocol.test.ts`
  - Does not reach test execution in this environment. Jest fails during
    startup with `TypeError: Attempted to assign to readonly property` from
    `jest-runtime` / `stack-utils`, before any test cases run.
