### PR TITLE
fix(compaction): enable compaction for local ollama models (context_limit was 0 → silently skipped)

### DIFF
--- a/src/core/context_usage.ail
+++ b/src/core/context_usage.ail
@@ -42,6 +42,7 @@ pure func context_limit_base(model: string) -> int
     else if startsWith(model, "openai/") then 128000
     else if startsWith(model, "google/") then 1000000
     else if startsWith(model, "deepseek/deepseek-v4") then 1000000
+    else if startsWith(model, "ollama/qwen3") then 262144
     else if model == "test/tiny" then 100
     else 0
   }
@@ -50,6 +51,7 @@ export pure func context_limit_for(model: string) -> int
   ensures { result >= 0 }
   tests [
     ("anthropic/claude-sonnet-4-6",                 200000),
+    ("ollama/qwen3.6:35b-a3b-mxfp8",                262144),
     ("google/gemini-2.5-pro",                       2000000),
     ("openrouter/anthropic/claude-sonnet-4-5",      200000),
     ("openrouter/z-ai/glm-5",                       128000),


### PR DESCRIPTION
**Compaction has been silently off for every local-qwen motoko run.**

`context_limit_base()` (src/core/context_usage.ail) has no `ollama/` entry, so `context_limit_for("ollama/qwen3.6:35b-a3b-mxfp8")` falls through to `0`. Per `compaction.ail`: *"For unknown models (context_limit_for returns 0), compaction is skipped."* So compaction never fires on the local rig.

- **Latent** on the saturated small-benchmark set (context never grows enough to matter).
- **Fatal** on large-context: the docx_reimplement P0 instrument overflowed at **291k > 262k tokens** (step 24) because nothing was compacting.

Fix: `startsWith(model, "ollama/qwen3") -> 262144` (the model's real context window) + a contract test. **Validated:** with the fix, a docx run reached the context-heavy phase with **no overflow**, where the unfixed run blew the 256k window. DRAFT pending the full docx convergence (also gated on the BashExec-timeout fix, ailang-side).