### PR TITLE
feat(tools): ReadInterface — read a module's typed interface, not its full source

### DIFF
--- a/src/core/tool_catalog.ail
+++ b/src/core/tool_catalog.ail
@@ -66,9 +66,16 @@ pure func search_schema() -> ToolSchema = {
 
 -- The full tool catalog motoko_agent advertises to the model. Pass this
 -- to upstream `runTools(model, msgs, tools(), dispatch, budget)`.
+pure func read_interface_schema() -> ToolSchema = {
+  name: "ReadInterface",
+  description: "Read a module's TYPED INTERFACE — exported declarations as one-line signatures with types and effect rows (plus ADT constructors) — instead of its full source. ~10x smaller than ReadFile (and the model otherwise re-reads full files to re-find signatures). Use this to learn how to USE a dependency/module; use ReadFile only for the file you are actually editing.",
+  parameters: "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\",\"description\":\"Path to the .ail module\"}},\"required\":[\"path\"]}"
+}
+
 export pure func tools() -> [ToolSchema] {
   [
     read_file_schema(),
+    read_interface_schema(),
     write_file_schema(),
     edit_file_schema(),
     bash_exec_schema(),

--- a/src/core/tool_runtime.ail
+++ b/src/core/tool_runtime.ail
@@ -141,7 +141,7 @@ func parse_edit_ops_rec(xs: [Json]) -> [EditOp] {
 }
 
 export pure func backend_for(call: ToolCallEnvelope, ohmy_pi: bool) -> ToolBackend {
-  if call.tool == "ReadFile" || call.tool == "WriteFile" || call.tool == "EditFile" || call.tool == "Search" then
+  if call.tool == "ReadFile" || call.tool == "WriteFile" || call.tool == "EditFile" || call.tool == "Search" || call.tool == "ReadInterface" then
     if ohmy_pi then Delegated else Native
   else if call.tool == "BashExec" || call.tool == "RunTests" then
     if needs_delegation_for_process(parse_exec_from_args(call.arguments)) then Delegated else Native
@@ -166,6 +166,8 @@ func run_native_call(call: ToolCallEnvelope, workdir: string) -> ToolResultItem 
   let args = call.arguments;
   if call.tool == "ReadFile" then
     run_read_file(call.id, arg_string(args, "path", ""), arg_number(args, "start", 1), arg_number(args, "end", 200), workdir)
+  else if call.tool == "ReadInterface" then
+    run_read_interface(call.id, arg_string(args, "path", ""), workdir)
   else if call.tool == "Search" then
     run_search(call.id, arg_string(args, "pattern", ""), arg_string(args, "dir", "."), workdir)
   else if call.tool == "WriteFile" then
@@ -618,6 +620,23 @@ func run_write_file(id: string, path: string, content: string, workdir: string) 
   }
 }
 
+func run_read_interface(id: string, path: string, workdir: string) -> ToolResultItem ! {FS, Process} {
+  match validate_path_common("ReadInterface", id, path, workdir) {
+    Err(e) => e,
+    Ok(_) => {
+      let resolved = resolve_workdir_path(workdir, path);
+      match exec("ailang", ["iface", "--compact", resolved]) {
+        Err(err) => ToolErrorResult({ id: id, tool: "ReadInterface", message: process_error_to_string(err) }),
+        Ok(out) =>
+          if out.exitCode == 0 then
+            ReadFileResult({ id: id, path: path, content: toString(out.stdout), line_count: 0, truncated: false, sha256: "" })
+          else
+            ToolErrorResult({ id: id, tool: "ReadInterface", message: "ailang iface failed: ${toString(out.stderr)}" })
+      }
+    }
+  }
+}
+
 func path_dirname(path: string) -> string {
   if startsWith(path, "/") then {
     let rel = substring(path, 1, length(path));
@@ -993,7 +1012,7 @@ func t_normalize_relative_path() -> bool
 -- use the normal delegation check (streaming/hard-cancel requirements).
 -- See: design_docs/planned/m-motoko-path-doubling-v2.md
 export pure func backend_for_v2(call: ToolCallEnvelope, ohmy_pi: bool) -> ToolBackend {
-  if call.tool == "ReadFile" || call.tool == "WriteFile" || call.tool == "EditFile" || call.tool == "Search" then
+  if call.tool == "ReadFile" || call.tool == "WriteFile" || call.tool == "EditFile" || call.tool == "Search" || call.tool == "ReadInterface" then
     Native
   else
     backend_for(call, ohmy_pi)


### PR DESCRIPTION
Adds a **ReadInterface** tool: returns a module's compact typed interface — one-line signatures with types **and effect rows**, plus ADT constructors — via `ailang iface --compact`, instead of dumping the full file. The agent learns how to *use* a dependency without reading its implementation.

**Why:** on large-context tasks the agent burns context reading dependency *bodies* just to learn signatures — the docx_reimplement wall was ~38 ReadFile calls → 262k-token overflow.

**A/B (qwen3.6, n=2, a zip_extract-using task):**
- **Adoption:** the agent picked ReadInterface **2/2** when nudged (even queried `std/string`) — unlike EditDecl (1/3).
- **Context win realized + amplified:** ReadInterface read the 280-line dep **once** (~870 B); the ReadFile-only arm **re-read the full file 2–3×** (~17–25 KB) → **~20–30× less** dep-context (the model re-reads full files to re-find sigs, so a dense interface read once wins big).
- **Correctness preserved:** dep usage correct in both arms; the one compile failure was an unrelated AILANG `let`-block syntax error, not a dep error. Token reduction also cuts latency + cost (smaller prefill).

**Depends on** `ailang iface --compact` (ailang-side dense renderer). **DRAFT** pending a larger multi-dep A/B to firm the magnitude. This is the first of an **AST-query** toolset (TypeAt / GoToDef / FindCallers next) — reflecting the edit-vs-query split we found: *querying* the typed AST helps; *editing* it (EditDecl #66) was neutral for pass-rate.